### PR TITLE
Add otel datadog docs

### DIFF
--- a/docs/kubernetes/onboarding.mdx
+++ b/docs/kubernetes/onboarding.mdx
@@ -99,7 +99,7 @@ Choose how the Kestrel Operator will collect infrastructure and workload metrics
     - You already have Datadog deployed in your cluster
     - You want the Kestrel Operator to leverage your existing Datadog metrics for incident analysis
 
-    When selected, you'll need to specify the **Datadog namespace** — the Kubernetes namespace where your Datadog agents are deployed (commonly `datadog` or `default`). The Kestrel Operator will auto-discover the API key, application key, and Datadog site from your existing Datadog secrets.
+    When selected, you'll need to specify the **Datadog namespace** — the Kubernetes namespace where your Datadog agents are deployed (commonly `datadog` or `default`). The Kestrel Operator will auto-discover the API key, application key, and Datadog site from your existing Datadog secrets. See the [Datadog integration guide](/kubernetes/datadog) for full setup and troubleshooting details.
   </Tab>
 </Tabs>
 

--- a/docs/kubernetes/onboarding.mdx
+++ b/docs/kubernetes/onboarding.mdx
@@ -59,6 +59,50 @@ Choose how the operator will collect network traffic data:
   </Tab>
 </Tabs>
 
+### Metrics Source
+
+Choose how the Kestrel Operator will collect infrastructure and workload metrics for incident analysis and root cause investigation:
+
+<Tabs>
+  <Tab title="Kubernetes Metrics Server">
+    **Kubernetes Metrics Server** (Default)
+    - Uses the built-in K8s Metrics API if available
+    - No additional configuration required
+    - Provides basic CPU and memory usage data for pods and nodes
+
+    Use this option if:
+    - You have the Kubernetes Metrics Server installed (most clusters do by default)
+    - You don't need historical metrics or advanced monitoring
+  </Tab>
+
+  <Tab title="OpenTelemetry">
+    **OpenTelemetry Collector**
+    - Receives metrics from an OTEL Collector via OTLP gRPC
+    - Requires an OpenTelemetry Collector deployed in your cluster
+    - Provides rich Kubernetes and application-level metrics
+
+    Use this option if:
+    - You already have an OpenTelemetry Collector deployed
+    - You want granular, standardized metrics with flexible pipelines
+    - You need application-level metrics alongside infrastructure metrics
+
+    The Kestrel Operator will automatically receive metrics pushed by your OTEL Collector. See the [OpenTelemetry configuration guide](/kubernetes/configuration) for collector setup details.
+  </Tab>
+
+  <Tab title="Datadog">
+    **Datadog**
+    - Queries metrics from in-cluster Datadog agents
+    - Requires Datadog Agent and/or Cluster Agent deployed in your cluster
+    - Provides historical metrics, events, hosts, and logs from Datadog
+
+    Use this option if:
+    - You already have Datadog deployed in your cluster
+    - You want the Kestrel Operator to leverage your existing Datadog metrics for incident analysis
+
+    When selected, you'll need to specify the **Datadog namespace** — the Kubernetes namespace where your Datadog agents are deployed (commonly `datadog` or `default`). The Kestrel Operator will auto-discover the API key, application key, and Datadog site from your existing Datadog secrets.
+  </Tab>
+</Tabs>
+
 ### Safe-Apply Permissions
 
 <Warning>
@@ -125,6 +169,16 @@ operator:
   #   disableFlows: true
   # istio:
   #   enabled: true
+
+  # Metrics source (uncomment one)
+  # For OpenTelemetry:
+  # otel:
+  #   enabled: true
+
+  # For Datadog:
+  # datadog:
+  #   enabled: true
+  #   namespace: "datadog"  # Namespace where Datadog agents are deployed
 
   # Enable safe-apply if granted permissions
   safeApply:

--- a/docs/kubernetes/overview.mdx
+++ b/docs/kubernetes/overview.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Operator Overview"
+title: "Kestrel Operator Overview"
 description: "Understanding the Kestrel Operator and its role in your Kubernetes security architecture"
 ---
 
@@ -39,6 +39,10 @@ Maintains a secure gRPC connection to Kestrel Cloud using mTLS authentication. H
 - **Cilium Integration**: Collects L3/L4 network flows from Hubble Relay
 - **Istio Integration**: Receives L7 access logs via Envoy Access Log Service
 
+### Metrics Integrations
+- **OpenTelemetry**: Receives metrics from an OTEL Collector via OTLP gRPC
+- **Datadog**: Queries metrics from in-cluster Datadog agents
+
 ## Security Model
 
 ### Authentication
@@ -57,9 +61,11 @@ Maintains a secure gRPC connection to Kestrel Cloud using mTLS authentication. H
 - Cluster admin permissions for installation
 - Network connectivity to `grpc.platform.usekestrel.ai:443`
 
-### Optional Components
+### Optional Integrations
 - **Cilium** (for L3/L4 network flow collection)
 - **Istio** (for L7 access log collection and authorization policies)
+- **OpenTelemetry Collector** (for receiving Kubernetes and application metrics via OTLP gRPC)
+- **Datadog** (for querying historical metrics, events, and logs from in-cluster Datadog agents)
 
 ## Next Steps
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Kubernetes onboarding guide with a new "Metrics Source" section detailing three metrics collection options: Kubernetes Metrics Server, OpenTelemetry, and Datadog, including setup notes and configuration examples.
  * Enhanced operator overview with metrics integrations architecture details and restructured optional components section.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->