### PR TITLE
Fix event ingester re-syncing stale K8s events every 5 minutes

### DIFF
--- a/pkg/ingestion/event_ingester.go
+++ b/pkg/ingestion/event_ingester.go
@@ -98,7 +98,7 @@ func (ei *EventIngester) setupEventInformer() {
 			// if the ResourceVersion is unchanged, it's a no-op re-sync, not a real update.
 			if oldEvent, ok := oldObj.(*corev1.Event); ok {
 				if oldEvent.ResourceVersion == newEvent.ResourceVersion {
-					ei.logger.Debug("Skipping re-synced event (unchanged ResourceVersion)",
+					ei.logger.Info("Skipping re-synced event (unchanged ResourceVersion)",
 						zap.String("reason", newEvent.Reason),
 						zap.String("involvedObject", fmt.Sprintf("%s/%s", newEvent.InvolvedObject.Kind, newEvent.InvolvedObject.Name)),
 						zap.String("namespace", newEvent.InvolvedObject.Namespace),

--- a/pkg/ingestion/event_ingester.go
+++ b/pkg/ingestion/event_ingester.go
@@ -98,7 +98,7 @@ func (ei *EventIngester) setupEventInformer() {
 			// if the ResourceVersion is unchanged, it's a no-op re-sync, not a real update.
 			if oldEvent, ok := oldObj.(*corev1.Event); ok {
 				if oldEvent.ResourceVersion == newEvent.ResourceVersion {
-					ei.logger.Info("Skipping re-synced event (unchanged ResourceVersion)",
+					ei.logger.Debug("Skipping re-synced event (unchanged ResourceVersion)",
 						zap.String("reason", newEvent.Reason),
 						zap.String("involvedObject", fmt.Sprintf("%s/%s", newEvent.InvolvedObject.Kind, newEvent.InvolvedObject.Name)),
 						zap.String("namespace", newEvent.InvolvedObject.Namespace),

--- a/pkg/ingestion/event_ingester.go
+++ b/pkg/ingestion/event_ingester.go
@@ -83,29 +83,34 @@ func (ei *EventIngester) setupEventInformer() {
 	_, err := eventInformer.AddEventHandler(cache.ResourceEventHandlerFuncs{
 		AddFunc: func(obj interface{}) {
 			if event, ok := obj.(*corev1.Event); ok {
-				// Send Warning events for incident detection
 				if event.Type == corev1.EventTypeWarning {
 					ei.sendEvent(event, "CREATE")
 				}
 			}
 		},
 		UpdateFunc: func(oldObj, newObj interface{}) {
-			if event, ok := newObj.(*corev1.Event); ok {
-				// Send updates for Warning events (count increases indicate repeated issues)
-				if event.Type == corev1.EventTypeWarning {
-					ei.sendEvent(event, "UPDATE")
+			newEvent, ok := newObj.(*corev1.Event)
+			if !ok || newEvent.Type != corev1.EventTypeWarning {
+				return
+			}
+			// The informer re-sync (every 5 min) fires UpdateFunc for ALL cached objects,
+			// including stale K8s events that haven't changed. Detect and skip these:
+			// if the ResourceVersion is unchanged, it's a no-op re-sync, not a real update.
+			if oldEvent, ok := oldObj.(*corev1.Event); ok {
+				if oldEvent.ResourceVersion == newEvent.ResourceVersion {
+					ei.logger.Debug("Skipping re-synced event (unchanged ResourceVersion)",
+						zap.String("reason", newEvent.Reason),
+						zap.String("involvedObject", fmt.Sprintf("%s/%s", newEvent.InvolvedObject.Kind, newEvent.InvolvedObject.Name)),
+						zap.String("namespace", newEvent.InvolvedObject.Namespace),
+						zap.String("resourceVersion", newEvent.ResourceVersion))
+					return
 				}
 			}
+			ei.sendEvent(newEvent, "UPDATE")
 		},
-		DeleteFunc: func(obj interface{}) {
-			obj = unwrapDeletedObject(obj)
-			if event, ok := obj.(*corev1.Event); ok {
-				// Track deletion of warning events
-				if event.Type == corev1.EventTypeWarning {
-					ei.sendEvent(event, "DELETE")
-				}
-			}
-		},
+		// DeleteFunc intentionally omitted: K8s event deletion is garbage collection
+		// (default 1-hour TTL), not an incident signal. Sending deleted events would
+		// inject stale signals into the server's incident detection pipeline.
 	})
 	if err != nil {
 		ei.logger.Error("Failed to add event event handler", zap.Error(err))


### PR DESCRIPTION
The shared informer factory's periodic re-sync fires UpdateFunc for all cached objects, even when unchanged. The event ingester had no dedup, causing every Warning event to be re-sent to the server on each 5-min cycle with its original stale timestamp. This inflated persistence duration and created false-positive incidents for already-recovered workloads.

- Skip UpdateFunc when ResourceVersion is unchanged (no-op re-sync)
- Remove DeleteFunc: K8s event deletion is garbage collection (1-hour TTL), not an incident signal
- Add debug logging for skipped re-sync events

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Only warning-type events are processed; non-warning or malformed events are ignored to reduce noise.
  * Redundant update notifications are skipped when an event's resource version is unchanged, preventing duplicate handling.
  * Removed duplicate deletion emissions for warning events to streamline event flow and reduce unnecessary messages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->