### PR TITLE
docs: add workflow rollback and execution replay documentation

### DIFF
--- a/docs/workflows/cli.mdx
+++ b/docs/workflows/cli.mdx
@@ -170,6 +170,22 @@ kestrel approvals approve <approval-id> --justification "Emergency fix"
 kestrel approvals reject <approval-id>
 ```
 
+## Version History & Rollback
+
+```bash
+kestrel workflows versions <workflow-id>              # List version history
+kestrel workflows rollback <workflow-id> --version 3  # Roll back to version 3
+```
+
+## Execution Replay
+
+Replay failed executions from the beginning or from the failed step:
+
+```bash
+kestrel workflows replay <execution-id>                   # Replay from beginning
+kestrel workflows replay <execution-id> --from-failed     # Replay from failed step
+```
+
 ## Request Commands
 
 ```bash

--- a/docs/workflows/sdk.mdx
+++ b/docs/workflows/sdk.mdx
@@ -444,6 +444,34 @@ client.approvals.approve("approval-id", justification="Looks good")
 client.approvals.reject("approval-id")
 ```
 
+## Version History & Rollback
+
+```python
+# List version history
+versions = client.workflows.list_versions("workflow-id")
+for v in versions["versions"]:
+    print(f"v{v['version_number']} — {v['change_summary']} ({v['created_at']})")
+
+# Roll back to a previous version
+client.workflows.rollback("workflow-id", version=3)
+```
+
+## Execution Replay
+
+Replay failed executions from the beginning or from the failed step:
+
+```python
+# Replay from beginning (re-triggers with same signal data)
+new_exec = client.executions.replay("execution-id", mode="full")
+
+# Replay from failed step (preserves outputs from prior steps)
+new_exec = client.executions.replay("execution-id", mode="from_failed")
+
+# Wait for replay to complete
+result = client.executions.wait(new_exec.id)
+print(f"Replay status: {result.status}")
+```
+
 ## Error Handling
 
 ```python


### PR DESCRIPTION
CLI:
- kestrel workflows versions <id> — list version history
- kestrel workflows rollback <id> --version N — roll back to version
- kestrel workflows replay <execution-id> — replay from beginning
- kestrel workflows replay <execution-id> --from-failed — replay from failed step

SDK:
- client.workflows.rollback(id, version=N)
- client.workflows.list_versions(id)
- client.executions.replay(id, mode="full"|"from_failed")

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added CLI documentation for version history, rollback, and execution replay functionality.
  * Added Python SDK documentation for version history, rollback, and execution replay functionality.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/KestrelAI/Kestrel-Operator/pull/49?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->