### PR TITLE
docs: add Trigger.github_push() to SDK reference

### DIFF
--- a/docs/workflows/mcp.mdx
+++ b/docs/workflows/mcp.mdx
@@ -133,6 +133,12 @@ If `kestrel` isn't on your PATH, use the full path (e.g., `/usr/local/bin/kestre
 
 The AI agent calls `generate_workflow`, reviews the result, then `create_workflow` and `activate_workflow`.
 
+**Creating a push-triggered workflow:**
+
+> "Create a workflow that triggers when code is pushed to main in the KestrelAI/AutoNP repo, then trigger the deploy GitHub Action"
+
+The agent uses `generate_workflow` with a GitHub push trigger (`signal_type: push`, filtered to the repo and branch).
+
 **Checking executions:**
 
 > "Show me the last 5 failed workflow executions and what went wrong"

--- a/docs/workflows/mcp.mdx
+++ b/docs/workflows/mcp.mdx
@@ -133,12 +133,6 @@ If `kestrel` isn't on your PATH, use the full path (e.g., `/usr/local/bin/kestre
 
 The AI agent calls `generate_workflow`, reviews the result, then `create_workflow` and `activate_workflow`.
 
-**Creating a push-triggered workflow:**
-
-> "Create a workflow that triggers when code is pushed to main in the KestrelAI/AutoNP repo, then trigger the deploy GitHub Action"
-
-The agent uses `generate_workflow` with a GitHub push trigger (`signal_type: push`, filtered to the repo and branch).
-
 **Checking executions:**
 
 > "Show me the last 5 failed workflow executions and what went wrong"

--- a/docs/workflows/sdk.mdx
+++ b/docs/workflows/sdk.mdx
@@ -144,6 +144,7 @@ Trigger.github_pr_merged()
 Trigger.github_pr_approved()
 Trigger.github_action_completed()
 Trigger.github_action_failed()
+Trigger.github_push()                                                          # New commits pushed to branch
 
 # PostHog
 Trigger.posthog_exception()


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a GitHub "push" trigger example to the workflow trigger docs.
  * Added an example conversation showing how to create a push-triggered workflow filtered to a specific repo and branch.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->