### PR TITLE
docs: update tagline to 'AI Agents for Platform Engineering'

### DIFF
--- a/docs/introduction.mdx
+++ b/docs/introduction.mdx
@@ -1,9 +1,9 @@
 ---
 title: "Introduction"
-description: "Kestrel documentation - AI Agents for Cloud Operations"
+description: "Kestrel documentation - AI Agents for Platform Engineering"
 ---
 
-Kestrel is the agentic platform for cloud operations. Build workflows that automate incident response, cloud provisioning, CI/CD pipelines, and developer requests — using natural language, a drag-and-drop canvas, CLI, SDK, or MCP. Monitor Kubernetes and cloud infrastructure 24/7 with AI agents that detect, investigate, and fix incidents in seconds. Ask any question about your infrastructure through a conversational AI copilot. Connect 15+ integrations, describe what you want, and let AI agents handle the rest.
+Kestrel is the agentic platform for platform engineering. Build workflows that automate incident response, cloud provisioning, CI/CD pipelines, and developer requests — using natural language, a drag-and-drop canvas, CLI, SDK, or MCP. Monitor Kubernetes and cloud infrastructure 24/7 with AI agents that detect, investigate, and fix incidents in seconds. Ask any question about your infrastructure through a conversational AI copilot. Connect 15+ integrations, describe what you want, and let AI agents handle the rest.
 
 {/* Screenshot placeholder: Kestrel platform overview showing the workflow canvas */}
 

--- a/docs/mint.json
+++ b/docs/mint.json
@@ -157,7 +157,7 @@
   },
   "metadata": {
     "og:title": "Kestrel AI Documentation",
-    "og:description": "AI Agents for Cloud Operations. Automate incident response, cloud provisioning, CI/CD, and more with intelligent workflows.",
+    "og:description": "AI Agents for Platform Engineering. Automate incident response, cloud provisioning, CI/CD, and more with intelligent workflows.",
     "og:image": "https://usekestrel.ai/og-image.png",
     "twitter:card": "summary_large_image"
   },

--- a/docs/workflows/sdk.mdx
+++ b/docs/workflows/sdk.mdx
@@ -255,7 +255,7 @@ Action.kestrel_generate_helm_values().chart_name("nginx-ingress")
 Action.kestrel_apply_k8s_manifest()
 Action.kestrel_create_gitops_pr().repo("org/k8s-manifests")
 
-# Kestrel — Cloud Operations
+# Kestrel — Platform Engineering
 Action.kestrel_generate_cloud_resource().cloud_service("rds").output_format("terraform")
 Action.kestrel_execute_cloud_cli()
 Action.kestrel_create_iac_pr().repo("org/infra-repo")


### PR DESCRIPTION
## Summary

- Updates all instances of the tagline "AI Agents for Cloud Operations" to "AI Agents for Platform Engineering" across documentation
- Reflects the new brand positioning

## Files changed

- `docs/mint.json` — og:description meta tag
- `docs/introduction.mdx` — page description and intro paragraph
- `docs/workflows/sdk.mdx` — heading


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated product positioning and descriptions across documentation to reflect Kestrel's platform focus.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->