### PR TITLE
fix: add namespaces to safe-apply ClusterRole

### DIFF
--- a/helm/kestrel-operator/templates/clusterrole-safeapply.yaml
+++ b/helm/kestrel-operator/templates/clusterrole-safeapply.yaml
@@ -13,6 +13,7 @@ rules:
   # Allow creating, updating, and deleting core resources for safe-apply
   - apiGroups: [""]
     resources: 
+      - "namespaces"
       - "pods"
       - "configmaps"
       - "secrets"


### PR DESCRIPTION
## Summary

- Adds `namespaces` to the core API group resources in the `safe-apply` ClusterRole
- Required for workflows that create Kubernetes namespaces (e.g., "K8s Namespace Request with Slack Approval")
- Without this permission, `kubectl apply` fails with: "User cannot create resource namespaces in API group at the cluster scope"

## Test

Verified on staging cluster — namespace creation workflow now succeeds after patching the ClusterRole.

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Extended operator permissions to support namespace resource management, enabling create, update, patch, and delete operations on namespaces.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->