### PR TITLE
docs: add Fly.io workflow integration

### DIFF
--- a/docs/workflows/create-workflows.mdx
+++ b/docs/workflows/create-workflows.mdx
@@ -195,6 +195,17 @@ Triggered by Railway deployment and platform events. Filter by project, environm
 | Volume Usage Alert | Triggers when a Railway volume approaches its capacity |
 | CPU/RAM Monitor Alert | Triggers when a Railway service exceeds CPU or memory thresholds |
 
+### Fly.io
+
+Triggered by Fly.io machine lifecycle changes. Fly.io has no outbound webhooks, so Kestrel detects these events by polling the Fly Machines API and diffing machine state on a configurable interval. Filter by app, region, and event type, and set the poll cadence (1m / 5m / 15m / 30m).
+
+| Trigger Block | Description |
+|---|---|
+| Machine Crashed | Triggers when a Fly machine crashes (non-zero exit / OOM) |
+| Machine Stopped | Triggers when a machine transitions to stopped/suspended |
+| Machine Started | Triggers when a machine transitions to started |
+| App Down | Triggers when all of an app's machines are stopped/unhealthy |
+
 ### Custom Webhook
 
 Triggered by an HTTP POST to a unique webhook URL. Accepts any JSON payload with optional HMAC signature verification. See [Custom Integrations](/workflows/custom-integrations) for details.
@@ -248,6 +259,9 @@ Actions are grouped by integration. Each action produces output variables that d
   <Card title="Railway" icon="train">
     Get Deployment, Get Deployment Logs, Rollback, Redeploy, Restart, List Deployments, Set Variables, Investigate Railway
   </Card>
+  <Card title="Fly.io" icon="plane">
+    Restart Machine, Start Machine, Stop Machine, Suspend Machine, Cordon Machine, Uncordon Machine, Get Machine, Get Machine Events, List Machines, Set Secrets, Investigate Fly
+  </Card>
   <Card title="Approval Gates" icon="shield-check">
     Wait for Manual Approval, Wait for Slack Approval, Wait for PR/MR Approval
   </Card>
@@ -288,6 +302,10 @@ Template variables let you pass data between workflow steps. Use double curly br
 | `{{signal.deployment_id}}` | Railway trigger | Railway deployment ID |
 | `{{signal.service_id}}` | Railway trigger | Railway service ID |
 | `{{signal.environment_id}}` | Railway trigger | Railway environment ID |
+| `{{signal.app_name}}` | Fly.io trigger | Fly app name |
+| `{{signal.machine_id}}` | Fly.io trigger | Fly machine ID |
+| `{{signal.region}}` | Fly.io trigger | Fly region (e.g. iad) |
+| `{{signal.exit_code}}` | Fly.io trigger | Machine exit code (crash events) |
 | `{{signal.session_id}}` | PostHog trigger | PostHog session ID |
 
 ### Variable Picker
@@ -310,7 +328,7 @@ Cooldowns prevent a workflow from firing repeatedly for the same event. Configur
 |--------|----------|-------------|
 | No cooldown | 0 | — |
 | 5 minutes | 5m | — |
-| 10 minutes | 10m | Slack, PostHog, Vercel, Railway, custom webhook triggers |
+| 10 minutes | 10m | Slack, PostHog, Vercel, Railway, Fly.io, custom webhook triggers |
 | 30 minutes | 30m | — |
 | 1 hour | 1h | — |
 | 3 hours | 3h | — |
@@ -407,7 +425,17 @@ Test executions are marked as test runs in the [Observability dashboard](/workfl
 | **Action 3** | Rollback | Service: `{{signal.service_id}}`, Environment: `{{signal.environment_id}}` |
 | **Action 4** | Slack Send Message | Channel: `#platform`, message: `{{step_outputs.action-2.summary}}` |
 
-### PostHog Exception → Session Summary → Slack Alert
+### Fly.io Machine Crash → Events → Investigation → Restart → Slack
+
+**Workflow Agent prompt:** *"When a Fly.io machine crashes, pull its recent events, run an AI investigation to find the root cause, restart the machine, and post a summary to #platform in Slack."*
+
+| Step | Type | Configuration |
+|------|------|---------------|
+| **Trigger** | Fly.io Machine Crashed | All apps, poll every 1m |
+| **Action 1** | Get Machine Events | App: `{{signal.app_name}}`, Machine: `{{signal.machine_id}}` |
+| **Action 2** | Investigate Fly | Query: find why machine `{{signal.machine_id}}` crashed using `{{step_outputs.action-1.summary}}` |
+| **Action 3** | Restart Machine | App: `{{signal.app_name}}`, Machine: `{{signal.machine_id}}` |
+| **Action 4** | Slack Send Message | Channel: `#platform`, message: `{{step_outputs.action-2.summary}}` |
 
 **Workflow Agent prompt:** *"When PostHog captures a frontend exception, generate an AI summary of the user's session including what they were doing before the error, and send the summary with the replay URL to #product-alerts in Slack."*
 

--- a/docs/workflows/observability.mdx
+++ b/docs/workflows/observability.mdx
@@ -18,7 +18,7 @@ The top of the dashboard shows aggregate metrics across all workflows:
 | **Total Executions** | Number of workflow runs in the selected time range |
 | **Success Rate** | Percentage of executions that completed without errors |
 | **Active Workflows** | Number of enabled workflows |
-| **Trigger Sources** | Breakdown of executions by trigger type (K8s, Cloud, Slack, PagerDuty, PostHog, Vercel, Railway, Webhook) |
+| **Trigger Sources** | Breakdown of executions by trigger type (K8s, Cloud, Slack, PagerDuty, PostHog, Vercel, Railway, Fly.io, Webhook) |
 
 Use the date range picker in the top-right corner to adjust the time window. Defaults to the last 7 days.
 
@@ -83,7 +83,7 @@ The execution history table lists every workflow run with filtering and search.
 |--------|---------|
 | **Workflow** | Select a specific workflow or view all |
 | **Status** | Success, Failed, Running, Pending Approval, Timed Out |
-| **Trigger Source** | K8s Incident, Cloud Signal, Slack, PagerDuty, PostHog, Vercel, Railway, Webhook |
+| **Trigger Source** | K8s Incident, Cloud Signal, Slack, PagerDuty, PostHog, Vercel, Railway, Fly.io, Webhook |
 | **Date Range** | Custom start and end dates |
 
 {/* Screenshot placeholder: Execution history table with filter controls and status badges */}

--- a/docs/workflows/sdk.mdx
+++ b/docs/workflows/sdk.mdx
@@ -172,6 +172,13 @@ Trigger.railway_volume_alert()
 Trigger.railway_resource_alert()
 Trigger.railway_any()
 
+# Fly.io (poll-based)
+Trigger.flyio_machine_crashed()
+Trigger.flyio_machine_stopped()
+Trigger.flyio_machine_started()
+Trigger.flyio_app_down()
+Trigger.flyio_any()
+
 # Developer Requests (on-demand via Slack /kestrel-workflow, Kestrel Platform UI, or CLI)
 Trigger.request_kubernetes()    # Kubernetes operations
 Trigger.request_cloud()         # AWS / Cloud operations
@@ -235,6 +242,17 @@ trigger = (
     .cluster("cluster-id-1", "cluster-id-2")
     .namespace("production", "staging")
     .workload("api-server", "worker")
+)
+```
+
+Fly.io triggers are poll-based — set the apps, regions, and poll cadence to control how often Kestrel checks the Fly Machines API:
+
+```python
+trigger = (
+    Trigger.flyio_machine_crashed()
+    .fly_apps("my-app", "another-app")   # omit for all apps the token can see
+    .fly_regions("iad", "sjc")
+    .fly_poll_interval("1m")             # 1m | 5m | 15m | 30m
 )
 ```
 
@@ -374,6 +392,19 @@ Action.railway_restart().deployment_id("{{signal.deployment_id}}")
 Action.railway_list_deployments().config("service_id", "{{signal.service_id}}").config("status", "FAILED")
 Action.railway_set_variables().config("service_id", "{{signal.service_id}}").config("environment_id", "{{signal.environment_id}}").config("variables", {"LOG_LEVEL": "debug"})
 Action.railway_investigate().config("query", "Why did the service crash?")
+
+# Fly.io (machine-scoped: require app_name + machine_id)
+Action.flyio_restart_machine().app_name("{{signal.app_name}}").machine_id("{{signal.machine_id}}")
+Action.flyio_start_machine().app_name("{{signal.app_name}}").machine_id("{{signal.machine_id}}")
+Action.flyio_stop_machine().app_name("{{signal.app_name}}").machine_id("{{signal.machine_id}}")
+Action.flyio_suspend_machine().app_name("{{signal.app_name}}").machine_id("{{signal.machine_id}}")
+Action.flyio_cordon_machine().app_name("{{signal.app_name}}").machine_id("{{signal.machine_id}}")
+Action.flyio_uncordon_machine().app_name("{{signal.app_name}}").machine_id("{{signal.machine_id}}")
+Action.flyio_get_machine().app_name("{{signal.app_name}}").machine_id("{{signal.machine_id}}")
+Action.flyio_get_machine_events().app_name("{{signal.app_name}}").machine_id("{{signal.machine_id}}")
+Action.flyio_list_machines().app_name("{{signal.app_name}}").config("state", "started")
+Action.flyio_set_secrets().app_name("{{signal.app_name}}").config("secrets", {"API_KEY": "..."})
+Action.flyio_investigate().config("query", "Why did the machine crash?")
 
 # Approval Gates
 Action.approval_manual()

--- a/docs/workflows/setup-integrations.mdx
+++ b/docs/workflows/setup-integrations.mdx
@@ -90,6 +90,9 @@ You only need to connect an integration once. All workflows in your organization
   <Card title="Railway" icon="train" href="/integrations/railway">
     **Triggers:** Deployment Failed, Deployment Crashed, Deployment Succeeded, Volume Usage Alert, CPU/RAM Monitor Alert. **Actions:** Get Deployment, Get Deployment Logs, Rollback, Redeploy, Restart, List Deployments, Set Variables, Investigate Railway.
   </Card>
+  <Card title="Fly.io" icon="plane" href="/integrations/flyio">
+    **Triggers (poll-based):** Machine Crashed, Machine Stopped, Machine Started, App Down. **Actions:** Restart Machine, Start Machine, Stop Machine, Suspend Machine, Cordon Machine, Uncordon Machine, Get Machine, Get Machine Events, List Machines, Set Secrets, Investigate Fly.
+  </Card>
 </CardGroup>
 
 ## Cost Management


### PR DESCRIPTION
## Summary
- Adds Fly.io documentation to the workflows docs, stacked on top of `add-railway-workflow-docs` (so the diff shows only Fly additions).
- `create-workflows.mdx`: Fly.io trigger table (poll-based: machine crashed/stopped/started, app down), action card, template variables (`{{signal.app_name}}`, `{{signal.machine_id}}`, `{{signal.region}}`, `{{signal.exit_code}}`), cooldown note, and an example crash → events → investigate → restart → Slack workflow.
- `sdk.mdx`: Fly trigger/action factory methods + poll-based filter example (`.fly_apps`, `.fly_regions`, `.fly_poll_interval`).
- `setup-integrations.mdx`: Fly.io integration card.
- `observability.mdx`: Fly.io added to trigger-source breakdowns.

Fly.io has no outbound webhooks, so the docs explain that triggers are detected by polling the Fly Machines API on a configurable interval.

## Notes
- Base is `add-railway-workflow-docs` because that branch is not yet merged to `main`. Once Railway merges, this can be retargeted to `main`.

## Test plan
- [ ] Docs preview renders the new Fly.io tables/cards correctly
- [ ] Links/anchors resolve

Made with [Cursor](https://cursor.com)