### PR TITLE
docs(integrations): add Daytona integration page

### DIFF
--- a/docs/integrations/daytona.mdx
+++ b/docs/integrations/daytona.mdx
@@ -1,0 +1,85 @@
+---
+title: "Daytona"
+description: "Connect Daytona for sandbox, snapshot, and volume lifecycle, command execution, and AI investigation in workflows"
+---
+
+The Daytona integration connects Kestrel to your Daytona organization, enabling sandbox, snapshot, and volume lifecycle events to trigger workflows and giving AI agents access to sandbox state, snapshots, and volumes.
+
+Daytona supports webhooks for resource lifecycle events, but they are registered manually in the Daytona dashboard. Kestrel works either way: connect with just an API key and Kestrel polls the Daytona API on a configurable interval, or register a webhook for real-time events (the poller then acts as a backstop).
+
+## Prerequisites
+
+- **Organization Admin** role in Kestrel
+- Daytona account with an organization
+- A Daytona organization API key
+
+## Setup
+
+<Steps>
+  <Step title="Create an API key">
+    Create an API key from the Daytona dashboard (under **Keys**) or with the Daytona CLI (`daytona api-key create`). The key is sent as a bearer token to `https://app.daytona.io/api` to read sandbox, snapshot, and volume state and perform actions.
+  </Step>
+  <Step title="Connect in Kestrel">
+    1. Navigate to **Integrations → Daytona** in your Kestrel dashboard
+    2. Paste your **Daytona API key**.
+    3. (Optional) Set a custom **API URL** for self-hosted Daytona.
+    4. Choose a **Poll Interval** for trigger detection.
+    5. Click **Connect Daytona** — your Daytona organization appears as connected.
+  </Step>
+  <Step title="(Optional) Configure a webhook for real-time events">
+    After connecting, open the **Real-Time Webhook** card and **Generate Signing Secret**. In the Daytona dashboard, go to **Webhooks → Add Endpoint**, paste the Kestrel webhook URL and the signing secret, and subscribe to the sandbox, snapshot, and volume events. Kestrel verifies each delivery's signature before firing workflows.
+  </Step>
+</Steps>
+
+<Warning>
+  The API key grants access to your Daytona sandboxes, snapshots, and volumes. Treat it as a secret — Kestrel stores it encrypted.
+</Warning>
+
+<Note>
+  No webhook setup is required to get started. Kestrel polls the Daytona API on your configured interval; configure a webhook only if you want lower-latency event detection.
+</Note>
+
+## How It's Used
+
+### In Workflows
+
+**Trigger blocks:**
+- **Sandbox Created** — fires when a new sandbox is created
+- **Sandbox Stopped** — fires when a sandbox transitions out of the started state
+- **Sandbox Error** — fires when a sandbox enters an error or build-failed state
+- **Sandbox Archived** — fires when a sandbox is archived
+- **Sandbox Execution Failed** — fires when a command run in a sandbox via a workflow exits non-zero
+- **Snapshot Build Failed** — fires when a snapshot enters an error/build-failed state
+- **Volume Error** — fires when a volume enters an error state
+
+Filter triggers by sandbox and event type. Kestrel detects these via webhook (when configured) or by polling the Daytona API on your configured interval.
+
+**Action blocks:**
+- **List Sandboxes** — list the sandboxes in the organization
+- **Get Sandbox** — retrieve a sandbox's state and metadata
+- **Start Sandbox** — start a stopped sandbox
+- **Stop Sandbox** — stop a running sandbox (preserves state for restart)
+- **Archive Sandbox** — archive a stopped sandbox to free compute while retaining disk
+- **Delete Sandbox** — permanently delete a sandbox (gate behind an Approval node)
+- **Run Command in Sandbox** — execute a shell command in a sandbox and capture exit code and output
+- **Set Auto-Stop Interval** — set a sandbox's inactivity auto-stop interval for cost control
+- **List Snapshots** — list the snapshots in the organization
+- **Create Snapshot** — create a snapshot from a Docker image
+- **Delete Snapshot** — delete a snapshot by name or ID
+- **List Volumes** — list the volumes in the organization
+- **Get Volume** — retrieve a volume's state
+- **Investigate Daytona** — run an AI investigation of failing sandboxes, snapshots, and volumes
+
+Daytona sandbox, snapshot, and volume selects accept template variables like `{{signal.sandbox_id}}`, `{{signal.snapshot}}`, and `{{signal.volume}}` from the trigger.
+
+Example: A workflow triggers on a sandbox error, runs an AI investigation to diagnose the failure, posts a summary to Slack, and opens a Jira bug ticket.
+
+Example: A workflow triggers on a newly created sandbox and sets an auto-stop interval to keep idle compute costs down.
+
+## Disconnecting
+
+1. Navigate to **Integrations → Daytona**
+2. Click **Disconnect**
+3. Confirm the disconnection
+
+This stops Daytona polling and all Daytona workflow triggers. You can reconnect at any time.

--- a/docs/mint.json
+++ b/docs/mint.json
@@ -126,6 +126,7 @@
         "integrations/railway",
         "integrations/flyio",
         "integrations/nebius",
+        "integrations/daytona",
         "integrations/datadog",
         "integrations/opentelemetry",
         "integrations/argocd",

--- a/docs/workflows/setup-integrations.mdx
+++ b/docs/workflows/setup-integrations.mdx
@@ -96,6 +96,9 @@ You only need to connect an integration once. All workflows in your organization
   <Card title="Nebius AI Cloud" icon="microchip" href="/integrations/nebius">
     **Triggers (poll-based):** GPU Error, Maintenance Scheduled, Node Not Ready, Instance Stopped. **Actions:** Get Instance, Start Instance, Stop Instance, Restart Instance, List Instances, List Clusters, List Node Groups, Scale Node Group, Investigate Nebius.
   </Card>
+  <Card title="Daytona" icon="cube" href="/integrations/daytona">
+    **Triggers (webhook or poll-based):** Sandbox Created, Sandbox Stopped, Sandbox Error, Sandbox Archived, Sandbox Execution Failed, Snapshot Build Failed, Volume Error. **Actions:** List/Get/Start/Stop/Archive/Delete Sandbox, Run Command, Set Auto-Stop, List/Create/Delete Snapshot, List/Get Volume, Investigate Daytona.
+  </Card>
 </CardGroup>
 
 ## Cost Management


### PR DESCRIPTION
## Summary
- Add a dedicated **Daytona** integration docs page (`docs/integrations/daytona.mdx`) covering setup (API key + optional webhook), sandbox/snapshot/volume lifecycle triggers, action blocks, and the AI investigation block.
- Add Daytona to the integrations nav in `docs/mint.json`.
- Add a Daytona card to the workflow `setup-integrations` overview.

These are docs-only additions mirroring the existing Nebius/Beam integration pages. Daytona triggers support both a webhook receiver (Svix-style, registered in the Daytona dashboard) and a zero-setup polling fallback.

## Test plan
- [ ] Mintlify docs build succeeds (nav resolves `integrations/daytona`).
- [ ] Daytona page renders with correct front matter and cards.
- [ ] Setup-integrations overview shows the Daytona card.

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a new Daytona integration guide with setup steps, prerequisites, security notes, and disconnect behavior.
  * Documented supported event-ingestion options and available workflow triggers/actions.
  * Added Daytona to the integrations navigation and setup-integrations page for easier discovery.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->