### PR TITLE
docs(daytona): detail full API key creation flow

### DIFF
--- a/docs/integrations/daytona.mdx
+++ b/docs/integrations/daytona.mdx
@@ -17,7 +17,14 @@ Daytona supports webhooks for resource lifecycle events, but they are registered
 
 <Steps>
   <Step title="Create an API key">
-    Create an API key from the Daytona dashboard (under **Keys**) or with the Daytona CLI (`daytona api-key create`). The key is sent as a bearer token to `https://app.daytona.io/api` to read sandbox, snapshot, and volume state and perform actions.
+    In the Daytona dashboard, open **API Keys** in the left sidebar and click **Create API Key** (or use the CLI: `daytona api-key create`). Then:
+
+    1. Enter a **Key Name** (e.g. `kestrel`).
+    2. Optionally set an **Expires** date — leave blank for a non-expiring key, or pick a date and plan to rotate the key in Kestrel before it expires.
+    3. For **Permissions**, choose **Full Access** (simplest), or choose **Restricted** and grant **Read + Write + Delete** on **Sandboxes** and **Snapshots** plus **Read** on **Volumes**. The **Sandboxes** preset alone is not sufficient — snapshot and volume actions require those additional grants.
+    4. Click **Create** and copy the generated key (shown only once).
+
+    The key is sent as a bearer token to `https://app.daytona.io/api` to read sandbox, snapshot, and volume state and perform actions.
   </Step>
   <Step title="Connect in Kestrel">
     1. Navigate to **Integrations → Daytona** in your Kestrel dashboard


### PR DESCRIPTION
## Summary
Expands the **Create an API key** step on the Daytona integration page to match the actual Daytona console flow, which the previous one-liner glossed over:

- Navigate to **API Keys → Create API Key**.
- Set a **Key Name**.
- Optional **Expires** date (with a note to rotate before expiry).
- **Permissions**: recommend **Full Access**; document the **Restricted** equivalent (Read+Write+Delete on Sandboxes & Snapshots, Read on Volumes) and call out that the **Sandboxes** preset alone is insufficient for snapshot/volume actions.

## Test plan
- [ ] Mintlify docs build succeeds.
- [ ] Steps render correctly and match the Daytona console UI.

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded API key setup guidance with clearer step-by-step instructions.
  * Added details on where to create keys, how to name them, optional expiration settings, and required access permissions.
  * Clarified that the key should be copied once and used as a bearer token for accessing sandbox, snapshot, and volume state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->