### PR TITLE
Add PlanetScale integration docs

### DIFF
--- a/docs/integrations/planetscale.mdx
+++ b/docs/integrations/planetscale.mdx
@@ -47,7 +47,7 @@ PlanetScale delivers branch, deploy-request, and storage events to Kestrel via n
 
     1. In the PlanetScale dashboard at **app.planetscale.com**, open the database's **Settings → Webhooks → Add webhook** (or run `pscale webhook create <database>`).
     2. Set the **URL** to the Kestrel webhook URL shown on the **Integrations → PlanetScale** connect screen (it ends in `/api/webhooks/planetscale`).
-    3. Under **Events**, select the ones to forward — the deploy-request lifecycle (`deploy_request.opened`, `deploy_request.errored`, etc.), the branch events (`branch.ready`, `branch.anomaly`, …), and `cluster.storage`. Keep **Enable this webhook** checked and **Save webhook**.
+    3. Under **Events**, select the ones to forward. The available events depend on the database engine: all databases expose the branch events (`branch.ready`, `branch.anomaly`, `branch.primary_promoted`, `branch.sleeping`) and `cluster.storage`; **Vitess (MySQL) databases also expose the deploy-request lifecycle** (`deploy_request.opened`, `deploy_request.errored`, `deploy_request.closed`, …), which **Postgres databases do not**. Keep **Enable this webhook** checked and **Save webhook**.
     4. PlanetScale generates a unique **signing secret** for the webhook (shown on creation, and under **⋯ → Show secret**). Copy it and paste it into the **Webhook secret** field on the Kestrel connect screen. Repeat per database — paste each database's secret (Kestrel verifies every delivery against any of the stored secrets). To add a database later, paste its secret on the **Reconnect** form; existing secrets are kept.
   </Step>
 </Steps>
@@ -65,11 +65,11 @@ PlanetScale delivers branch, deploy-request, and storage events to Kestrel via n
 ### In Workflows
 
 **Trigger blocks:**
-- **Deploy Request Opened / Queued / In Progress / Schema Applied / Errored / Reverted / Closed** — the deploy-request (schema migration) lifecycle (webhook)
+- **Deploy Request Opened / Queued / In Progress / Schema Applied / Errored / Reverted / Closed** — the deploy-request (schema migration) lifecycle (webhook; **Vitess/MySQL databases only** — Postgres databases don't emit deploy-request webhook events)
 - **Branch Ready** — fires when a branch is created and ready to connect (webhook)
 - **Branch Anomaly (Insights)** — fires on a new insights anomaly, e.g. a slow query or replication lag (webhook)
 - **Branch Primary Promoted** / **Branch Sleeping** — branch lifecycle (webhook)
-- **Storage Threshold** — fires when a cluster/keyspace reaches a storage threshold (webhook)
+- **Storage Threshold** — fires when a cluster reaches a storage threshold (webhook)
 - **Backup Completed** / **Backup Failed** — fires when a branch backup completes or fails (poll-based)
 
 Filter triggers by database, branch, and event type.

--- a/docs/integrations/planetscale.mdx
+++ b/docs/integrations/planetscale.mdx
@@ -39,21 +39,21 @@ PlanetScale delivers branch, deploy-request, and storage events to Kestrel via n
     2. Paste your **Service Token ID** and **Service Token**.
     3. Enter your **Organization** name.
     4. Choose a **Backup Poll Interval** (how often Kestrel checks the backups API for backup completed/failed events).
-    5. Copy the generated **webhook signing secret** shown on the connect screen (used in the next step).
+    5. Paste the **webhook signing secret(s)** PlanetScale generated when you registered the webhook(s) in the next step — one per database. (You can connect first and add secrets later by reconnecting.)
     6. Click **Connect PlanetScale** — your PlanetScale organization appears as connected.
   </Step>
   <Step title="Register a webhook (per database)">
     Needed for the branch and deploy-request triggers:
 
-    1. In the PlanetScale dashboard at **app.planetscale.com**, open the database's **Settings → Webhooks → New webhook** (or run `pscale webhook create <database>`).
+    1. In the PlanetScale dashboard at **app.planetscale.com**, open the database's **Settings → Webhooks → Add webhook** (or run `pscale webhook create <database>`).
     2. Set the **URL** to the Kestrel webhook URL shown on the **Integrations → PlanetScale** connect screen (it ends in `/api/webhooks/planetscale`).
-    3. Select the **events** to forward (e.g. all `deploy_request.*` and `branch.*` events).
-    4. Set the webhook's **signing secret** to the value Kestrel generated on the connect screen, then **create and enable** the webhook.
+    3. Under **Events**, select the ones to forward — the deploy-request lifecycle (`deploy_request.opened`, `deploy_request.errored`, etc.), the branch events (`branch.ready`, `branch.anomaly`, …), and `cluster.storage`. Keep **Enable this webhook** checked and **Save webhook**.
+    4. PlanetScale generates a unique **signing secret** for the webhook (shown on creation, and under **⋯ → Show secret**). Copy it and paste it into the **Webhook secret** field on the Kestrel connect screen. Repeat per database — paste each database's secret (Kestrel verifies every delivery against any of the stored secrets). To add a database later, paste its secret on the **Reconnect** form; existing secrets are kept.
   </Step>
 </Steps>
 
 <Warning>
-  The service token grants access to your PlanetScale databases. Treat the token and the webhook signing secret as secrets — Kestrel stores both encrypted.
+  The service token grants access to your PlanetScale databases. Treat the token and the webhook signing secrets as secrets — Kestrel stores them encrypted.
 </Warning>
 
 <Note>

--- a/docs/integrations/planetscale.mdx
+++ b/docs/integrations/planetscale.mdx
@@ -11,7 +11,7 @@ PlanetScale delivers branch, deploy-request, and storage events to Kestrel via n
 
 - **Organization Admin** role in Kestrel
 - A PlanetScale account with at least one database
-- A PlanetScale **service token** (ID + token) with the database accesses you want to automate
+- A PlanetScale **service token** (ID + token) with `read_databases` organization access plus the database accesses for the blocks you'll use (see below)
 - The PlanetScale **organization** name (slug)
 - (For branch/deploy-request triggers) a PlanetScale webhook registered per database
 
@@ -19,9 +19,20 @@ PlanetScale delivers branch, deploy-request, and storage events to Kestrel via n
 
 <Steps>
   <Step title="Create a service token">
-    In the PlanetScale dashboard, open **Settings → Service tokens → New service token** (or run `pscale service-token create`). Grant it the accesses you want to automate (e.g. `read_branch`, `create_branch`, `read_deploy_request`, `create_deploy_request`, `deploy_deploy_request`, `read_backups`, `write_database`). Copy the **token ID** and **token** (shown once).
+    In the PlanetScale dashboard at **app.planetscale.com**, open **Settings → Service tokens → New service token** (or run `pscale service-token create`). Copy the **token ID** and **token** (shown once), then grant permissions in two scopes:
 
-    The token is sent in the `Authorization: <ID>:<TOKEN>` header to `https://api.planetscale.com` to read and manage branches, deploy requests, and backups.
+    **Organization access** (click *Add organization permissions*):
+    - `read_databases` — list and inspect the organization's databases (required; Kestrel uses it to validate the connection and populate dropdowns)
+
+    **Database access** (click *Select permissions*; use *Permissions for all databases* to cover every database, or scope to specific ones):
+    - `read_branch`, `create_branch`, `delete_branch` — branch blocks (create/get/list/delete, promote, safe migrations)
+    - `read_deploy_request`, `create_deploy_request`, `approve_deploy_request` — deploy-request blocks (create/get/list/deploy/revert/close/approve)
+    - `read_backups`, `write_backups` — backup blocks (list/create)
+    - `connect_branch` (and `connect_production_branch` for production) — branch password blocks (list/create/delete)
+
+    For a read-only setup (investigate + list/get blocks only), the `read_*` permissions alone are enough.
+
+    The token is sent in the `Authorization: <ID>:<TOKEN>` header to the PlanetScale API at `api.planetscale.com` to read and manage branches, deploy requests, and backups.
   </Step>
   <Step title="Connect in Kestrel">
     1. Navigate to **Integrations → PlanetScale** in your Kestrel dashboard.
@@ -34,7 +45,7 @@ PlanetScale delivers branch, deploy-request, and storage events to Kestrel via n
   <Step title="Register a webhook (per database)">
     Needed for the branch and deploy-request triggers:
 
-    1. In the PlanetScale dashboard, open the database's **Settings → Webhooks → New webhook** (or run `pscale webhook create <database>`).
+    1. In the PlanetScale dashboard at **app.planetscale.com**, open the database's **Settings → Webhooks → New webhook** (or run `pscale webhook create <database>`).
     2. Set the **URL** to the Kestrel webhook URL shown on the **Integrations → PlanetScale** connect screen (it ends in `/api/webhooks/planetscale`).
     3. Select the **events** to forward (e.g. all `deploy_request.*` and `branch.*` events).
     4. Set the webhook's **signing secret** to the value Kestrel generated on the connect screen, then **create and enable** the webhook.

--- a/docs/integrations/planetscale.mdx
+++ b/docs/integrations/planetscale.mdx
@@ -1,0 +1,92 @@
+---
+title: "PlanetScale"
+description: "Connect PlanetScale for database branch, deploy-request (schema migration), backup, and credential automation in workflows"
+---
+
+The PlanetScale integration connects Kestrel to your PlanetScale organization through the PlanetScale API, enabling branch and deploy-request (schema migration) events to trigger workflows and giving AI agents read-only access to your databases' state.
+
+PlanetScale delivers branch, deploy-request, and storage events to Kestrel via native webhooks you register per-database (the webhook receiver verifies the `X-PlanetScale-Signature` against the signing secret). PlanetScale has no backup webhook, so **Backup Completed** / **Backup Failed** are detected by polling the backups API on a per-tenant cadence. Because the poller only synthesizes backup events, it never double-fires with webhook-delivered events.
+
+## Prerequisites
+
+- **Organization Admin** role in Kestrel
+- A PlanetScale account with at least one database
+- A PlanetScale **service token** (ID + token) with the database accesses you want to automate
+- The PlanetScale **organization** name (slug)
+- (For branch/deploy-request triggers) a PlanetScale webhook registered per database
+
+## Setup
+
+<Steps>
+  <Step title="Create a service token">
+    In the PlanetScale dashboard, open **Settings → Service tokens → New service token** (or run `pscale service-token create`). Grant it the accesses you want to automate (e.g. `read_branch`, `create_branch`, `read_deploy_request`, `create_deploy_request`, `deploy_deploy_request`, `read_backups`, `write_database`). Copy the **token ID** and **token** (shown once).
+
+    The token is sent in the `Authorization: <ID>:<TOKEN>` header to `https://api.planetscale.com` to read and manage branches, deploy requests, and backups.
+  </Step>
+  <Step title="Connect in Kestrel">
+    1. Navigate to **Integrations → PlanetScale** in your Kestrel dashboard.
+    2. Paste your **Service Token ID** and **Service Token**.
+    3. Enter your **Organization** name.
+    4. Choose a **Backup Poll Interval** (how often Kestrel checks the backups API for backup completed/failed events).
+    5. Copy the generated **webhook signing secret** shown on the connect screen (used in the next step).
+    6. Click **Connect PlanetScale** — your PlanetScale organization appears as connected.
+  </Step>
+  <Step title="Register a webhook (per database)">
+    Needed for the branch and deploy-request triggers:
+
+    1. In the PlanetScale dashboard, open the database's **Settings → Webhooks → New webhook** (or run `pscale webhook create <database>`).
+    2. Set the **URL** to the Kestrel webhook URL shown on the **Integrations → PlanetScale** connect screen (it ends in `/api/webhooks/planetscale`).
+    3. Select the **events** to forward (e.g. all `deploy_request.*` and `branch.*` events).
+    4. Set the webhook's **signing secret** to the value Kestrel generated on the connect screen, then **create and enable** the webhook.
+  </Step>
+</Steps>
+
+<Warning>
+  The service token grants access to your PlanetScale databases. Treat the token and the webhook signing secret as secrets — Kestrel stores both encrypted.
+</Warning>
+
+<Note>
+  Branch and deploy-request triggers fire as soon as the webhook delivery is verified. Backup triggers are detected by polling, so there may be up to one poll interval of delay before a backup workflow fires. The minimum poll interval is 60 seconds.
+</Note>
+
+## How It's Used
+
+### In Workflows
+
+**Trigger blocks:**
+- **Deploy Request Opened / Queued / In Progress / Schema Applied / Errored / Reverted / Closed** — the deploy-request (schema migration) lifecycle (webhook)
+- **Branch Ready** — fires when a branch is created and ready to connect (webhook)
+- **Branch Anomaly (Insights)** — fires on a new insights anomaly, e.g. a slow query or replication lag (webhook)
+- **Branch Primary Promoted** / **Branch Sleeping** — branch lifecycle (webhook)
+- **Storage Threshold** — fires when a cluster/keyspace reaches a storage threshold (webhook)
+- **Backup Completed** / **Backup Failed** — fires when a branch backup completes or fails (poll-based)
+
+Filter triggers by database, branch, and event type.
+
+**Action blocks:**
+- **List Databases** / **Get Database** — inspect databases
+- **List Branches** / **Get Branch** / **Create Branch** / **Delete Branch** — manage branches
+- **Promote Branch to Production** — promote a branch (gate behind an Approval node)
+- **Set Safe Migrations** — enable/disable safe migrations on a branch
+- **List Deploy Requests** / **Get Deploy Request** — inspect deploy requests
+- **Create Deploy Request** — open a schema migration
+- **Deploy Deploy Request** — apply the schema change (gate behind an Approval node)
+- **Revert Deploy Request** — revert a deployed change (auto-revert on failure; gate behind an Approval node)
+- **Close Deploy Request** / **Approve Deploy Request** — close or approve a deploy request
+- **List Backups** / **Create Backup** — manage branch backups
+- **List/Create/Delete Branch Password** — manage branch credentials
+- **Investigate PlanetScale** — run an AI investigation of databases, branches, deploy requests, and backups
+
+PlanetScale database and branch selects accept template variables like `{{signal.database}}`, `{{signal.branch}}`, and `{{signal.deploy_request_number}}` from the trigger.
+
+Example (the flagship CI/CD flow): When a pull request is merged, create a PlanetScale deploy request, require approval, deploy the schema change, and post the result to `#releases` on Slack.
+
+Example (incident): When a deploy request errors, run an AI investigation, revert the deploy request, and page on-call via PagerDuty.
+
+## Disconnecting
+
+1. Navigate to **Integrations → PlanetScale**
+2. Click **Disconnect**
+3. Confirm the disconnection
+
+This stops all PlanetScale workflow triggers (polling and webhook). You can optionally remove the webhooks in the PlanetScale dashboard too. You can reconnect at any time.

--- a/docs/mint.json
+++ b/docs/mint.json
@@ -128,6 +128,7 @@
         "integrations/nebius",
         "integrations/daytona",
         "integrations/supabase",
+        "integrations/planetscale",
         "integrations/datadog",
         "integrations/opentelemetry",
         "integrations/argocd",

--- a/docs/workflows/setup-integrations.mdx
+++ b/docs/workflows/setup-integrations.mdx
@@ -102,6 +102,9 @@ You only need to connect an integration once. All workflows in your organization
   <Card title="Supabase" icon="database" href="/integrations/supabase">
     **Triggers (poll-based + webhook):** Project Health Degraded, Backup Failed, Read Replica Unhealthy, Usage/Quota Threshold, Branch Created, Branch Migration Failed (poll-based), Database Row Event (Database Webhook). **Actions:** List/Get Project, Get Project Health, Create/List/Get/Merge/Reset/Delete Branch, List Backups, Create Restore Point, Restore Backup (PITR), Setup/Remove Read Replica, Pause/Restore Project, Get/Update Network Restrictions, List API Keys, Investigate Supabase.
   </Card>
+  <Card title="PlanetScale" icon="database" href="/integrations/planetscale">
+    **Triggers (webhook + poll-based):** Deploy Request Opened/Queued/In Progress/Schema Applied/Errored/Reverted/Closed, Branch Ready, Branch Anomaly, Branch Primary Promoted, Branch Sleeping, Storage Threshold (webhook), Backup Completed/Failed (poll-based). **Actions:** List/Get Database, List/Get/Create/Delete Branch, Promote Branch, Set Safe Migrations, List/Get/Create/Deploy/Revert/Close/Approve Deploy Request, List/Create Backup, List/Create/Delete Branch Password, Investigate PlanetScale.
+  </Card>
 </CardGroup>
 
 ## Cost Management


### PR DESCRIPTION
## Summary
- Add `docs/integrations/planetscale.mdx` documenting the PlanetScale integration: prerequisites (service token + organization + webhook), setup steps using the real `pscale`/dashboard flow, the full trigger/action reference (noting webhook vs. backup-poller delivery), and disconnecting.
- Register `integrations/planetscale` in `docs/mint.json` navigation.
- Add a PlanetScale card to `docs/workflows/setup-integrations.mdx`.

## Test plan
- [ ] Mintlify preview renders the new page and nav entry.
- [ ] Links resolve (`/integrations/planetscale`).

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a new PlanetScale integration guide with prerequisites, token setup, and step-by-step connection instructions.
  * Documented supported workflow triggers and actions for branch and deploy-request lifecycle events, including webhook signature verification.
  * Explained backup handling via polling to avoid duplicate events, plus what happens on disconnect.
  * Updated the Integrations navigation and the Setup Integrations page to include PlanetScale.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->