### PR TITLE
docs: document CLI integrations commands and MCP integration tools

### DIFF
--- a/docs/workflows/cli.mdx
+++ b/docs/workflows/cli.mdx
@@ -234,3 +234,84 @@ kestrel workflows catalog          # Available triggers and actions
 kestrel workflows integrations     # Integration connection status
 kestrel workflows suggestions      # AI-suggested workflows
 ```
+
+## Integration Commands
+
+Connect, test, and disconnect integrations (cloud providers, CI/CD, databases, alerting, knowledge sources, and more) directly from the terminal. Aliases: `kestrel integration`, `kestrel int`.
+
+<Note>
+Your API key needs the `integrations:read` and `integrations:manage` scopes to manage integrations. The key created during onboarding includes them by default.
+</Note>
+
+### List integrations
+
+Shows every integration with its type and current connection status:
+
+```bash
+kestrel integrations list
+```
+
+### Connect an integration
+
+Each integration has its own `connect` subcommand:
+
+```bash
+kestrel integrations connect <name>
+```
+
+You can pass credentials as flags, but you don't have to — running the bare command walks you through setup interactively:
+
+- The CLI prints setup instructions for the integration (where to create the API token, which permissions to grant, etc.), mirroring the platform UI.
+- It prompts for each required value. **Secrets are read with hidden input** — they never appear on the command line or in your shell history.
+
+```bash
+$ kestrel integrations connect cloudflare
+Connecting Cloudflare
+
+  API token: Cloudflare dashboard -> My Profile -> API Tokens -> Create Token -> ...
+  Account ID: in the dashboard URL — dash.cloudflare.com/<account-id>/home.
+
+API token (hidden):
+Cloudflare account ID: 023e105f4ecef8ad9ca31a8372d0c353
+✓ Cloudflare connected
+```
+
+To see the flags and setup instructions for any integration:
+
+```bash
+kestrel integrations connect <name> --help
+```
+
+Non-secret values can be passed as flags; file-based credentials support a `--<flag>-file` variant:
+
+```bash
+kestrel integrations connect terraform --organization my-org
+kestrel integrations connect nebius --credentials-file authorized-key.json
+kestrel integrations connect confluence --base-url https://acme.atlassian.net --email me@acme.com
+```
+
+### Connection types
+
+| Type | Integrations | How it works |
+|------|--------------|--------------|
+| Token | Cloudflare, PagerDuty, Datadog, ArgoCD, Jenkins, CircleCI, Terraform Cloud, Pulumi Cloud, Vercel, Railway, Fly.io, Nebius, Beam, Daytona, Supabase, PlanetScale, Neon, ClickHouse, PostHog, and more | Prompts for API tokens/credentials (hidden input) and connects immediately |
+| OAuth | GitHub, GitLab, Slack | Prints an authorization/install URL to open in your browser |
+| Knowledge | Jira, Linear, Confluence, Notion, Glean | Connects and immediately runs a connection test |
+| Cluster | Kubernetes | Mints an operator token, writes a Helm values file, and prints the `helm install` command |
+| Cloud | AWS, OCI | AWS is a two-step IAM role flow (bootstrap, then verify with `--role-arn`); OCI prompts for API key details |
+
+### Test a connection
+
+```bash
+kestrel integrations test <name>
+```
+
+Supported for token integrations and knowledge sources.
+
+### Disconnect an integration
+
+```bash
+kestrel integrations disconnect <name>
+```
+
+OAuth, cluster, and cloud integrations must be disconnected in the Kestrel UI.

--- a/docs/workflows/mcp.mdx
+++ b/docs/workflows/mcp.mdx
@@ -125,6 +125,19 @@ If `kestrel` isn't on your PATH, use the full path (e.g., `/usr/local/bin/kestre
 | `get_catalog` | Available signal triggers and action blocks |
 | `get_integrations_status` | Integration connection status |
 
+### Integration Management
+
+| Tool | Description |
+|------|-------------|
+| `list_integrations` | List every integration with its type, required credential fields, and connection status |
+| `connect_integration` | Connect a token or knowledge-source integration, or get the browser URL for OAuth integrations (GitHub, GitLab, Slack) |
+| `test_integration` | Test a connected integration's credentials |
+| `disconnect_integration` | Disconnect a token integration or knowledge source |
+
+<Note>
+Kubernetes, AWS, and OCI use multi-step flows and must be connected with the [CLI](/workflows/cli#integration-commands) (`kestrel integrations connect <name>`) instead of MCP tools. For credential safety, prefer the CLI's interactive hidden prompts for secrets rather than pasting tokens into an agent chat.
+</Note>
+
 ## Example Conversations
 
 **Creating a workflow:**
@@ -144,3 +157,9 @@ The agent calls `list_workflows`, `list_executions`, then `get_execution` for fa
 > "Are there any pending approvals? Approve the production deployment one"
 
 The agent calls `list_pending_approvals`, identifies the right one, and calls `approve_step`.
+
+**Connecting an integration:**
+
+> "Connect our PagerDuty account to Kestrel"
+
+The agent calls `list_integrations` to find the required credential fields, asks you for the values, then calls `connect_integration` and verifies with `test_integration`.

--- a/docs/workflows/setup-integrations.mdx
+++ b/docs/workflows/setup-integrations.mdx
@@ -9,6 +9,10 @@ Workflows chain actions across multiple integrations. Before using an integratio
 You only need to connect an integration once. All workflows in your organization share the same integration connections.
 </Note>
 
+<Tip>
+Prefer the terminal? Every integration can also be connected with the [Kestrel CLI](/workflows/cli#integration-commands) (`kestrel integrations connect <name>` — it walks you through setup and prompts for secrets with hidden input) or by an AI coding agent through [MCP](/workflows/mcp).
+</Tip>
+
 ## Infrastructure
 
 <CardGroup cols={2}>


### PR DESCRIPTION
- CLI: add Integration Commands section (list/connect/test/disconnect, interactive setup with hidden secret prompts, connection type table)
- MCP: document list/connect/test/disconnect_integration tools with an example conversation
- Setup Integrations: point to CLI and MCP as alternative connect paths

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded CLI docs with detailed integration management instructions, including listing, connecting, disconnecting, and testing integrations, plus supported connection types and required API key scopes.
  * Added guidance for using integrations through MCP and the dashboard, with a new example flow for connecting an integration and notes on where certain integrations must be disconnected.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->