### PR TITLE
docs: document CLI registration and workflow-request confirmation flow

### DIFF
--- a/docs/workflows/cli.mdx
+++ b/docs/workflows/cli.mdx
@@ -33,6 +33,29 @@ sudo mv kestrel /usr/local/bin/
 
 ## Authentication
 
+### Create an Account
+
+New to Kestrel? You can sign up directly from the terminal:
+
+```bash
+kestrel register
+```
+
+You'll be prompted for a work email and password (8–30 characters, hidden input). If email verification is enabled on the server, a 6-character code is sent to your inbox — enter it at the prompt and you're logged in automatically. You can also verify later:
+
+```bash
+kestrel verify-email <code>
+```
+
+Non-interactive usage (e.g. from a coding agent or script):
+
+```bash
+kestrel register --email you@company.com --password '...' --server https://platform.usekestrel.ai
+kestrel verify-email ABC123
+```
+
+After verification the CLI saves your session to `~/.kestrel/config.json` and prints suggested next steps (`kestrel integrations connect ...`).
+
 ### API Key (recommended)
 
 Create an API key in the Kestrel platform under **Workflows > API Keys**, then:
@@ -170,6 +193,24 @@ $ kestrel workflows request "create a configmap"
   ✓ Matched workflow: On-Demand K8s Resource Provision
   ✓ Workflow is now executing.
 ```
+
+If no workflow matches your request, the CLI asks whether you want to send it to your platform team as a workflow request (instead of filing one automatically):
+
+```
+$ kestrel workflows request "set up a Redis cluster for the cache layer"
+  Routing request: set up a Redis cluster for the cache layer
+
+  ✗ No matching workflow found
+  Category: general
+
+  Send this to your platform team as a workflow request? They can
+  create a workflow to handle this type of request. [y/N]: y
+
+  ✓ Request sent to your platform team.
+  Request ID: 4f8a...
+```
+
+Answering `n` (or pressing Enter) dismisses the request — it won't appear in the platform's Workflow Requests page.
 
 ## Execution Commands
 

--- a/docs/workflows/mcp.mdx
+++ b/docs/workflows/mcp.mdx
@@ -90,7 +90,8 @@ If `kestrel` isn't on your PATH, use the full path (e.g., `/usr/local/bin/kestre
 | Tool | Description |
 |------|-------------|
 | `generate_workflow` | Generate a workflow from natural language |
-| `request_workflow` | Submit a request to trigger a matching workflow |
+| `request_workflow` | Submit a request to trigger a matching workflow. If nothing matches, returns `pending_confirmation` with a `request_id` |
+| `confirm_workflow_request` | Resolve a `pending_confirmation` request: confirm to send it to the platform team, or dismiss it. The agent asks you before calling this |
 | `list_suggested_workflows` | Get AI-suggested workflows |
 
 ### Execution Management
@@ -163,3 +164,9 @@ The agent calls `list_pending_approvals`, identifies the right one, and calls `a
 > "Connect our PagerDuty account to Kestrel"
 
 The agent calls `list_integrations` to find the required credential fields, asks you for the values, then calls `connect_integration` and verifies with `test_integration`.
+
+**Requesting a change with no matching workflow:**
+
+> "Request a Redis cluster for the cache layer"
+
+The agent calls `request_workflow`. When no workflow matches, it gets back `pending_confirmation` and asks whether you want to send the request to your platform team; based on your answer, it calls `confirm_workflow_request` to file or dismiss it.

--- a/docs/workflows/sdk.mdx
+++ b/docs/workflows/sdk.mdx
@@ -268,7 +268,15 @@ result = client.workflows.request("create a configmap for my-app in production")
 # If clarification is needed:
 if result.status == "awaiting_params":
     reply = client.workflows.request_reply(result.id, "use the prod-cluster, namespace=payments")
+
+# If no workflow matches, the request is held as pending_confirmation.
+# Confirm to send it to the platform team, or dismiss it:
+if result.status == "pending_confirmation":
+    client.workflows.request_confirm(result.id, True)   # file for the platform team
+    # client.workflows.request_confirm(result.id, False)  # dismiss
 ```
+
+The async client mirrors this via `client.requests.confirm(request_id, confirm)`.
 
 # Custom Webhook
 Trigger.custom_webhook("my-event-type")


### PR DESCRIPTION
## Summary
- **CLI docs**: new "Create an Account" section covering `kestrel register` and `kestrel verify-email` (interactive and non-interactive usage, session auto-save), plus the new confirm-or-dismiss prompt shown by `kestrel workflows request` when no workflow matches.
- **MCP docs**: added the `confirm_workflow_request` tool, updated `request_workflow` to describe the `pending_confirmation` status, and added an example conversation for the flow.
- **SDK docs**: documented `client.workflows.request_confirm(...)` (sync) and `client.requests.confirm(...)` (async) for resolving `pending_confirmation` requests.

## Test plan
- [ ] Preview docs render (Mintlify) for the three edited pages
- [ ] Verify command names/flags match kestrel-cli v0.24.0

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added documentation for a new account creation flow, including interactive and non-interactive registration, optional email verification, and session saving after successful verification.
  * Expanded workflow request guidance to cover what happens when no matching workflow is found, including confirmation and dismissal steps.
  * Updated developer-facing examples to show how to handle pending confirmation when submitting requests programmatically.

* **Bug Fixes**
  * Clarified request behavior so dismissed workflow requests won’t appear in the platform’s requests page.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->