### PR TITLE
docs: AWS cost optimization blocks and scheduled triggers

### DIFF
--- a/docs/integrations/aws.mdx
+++ b/docs/integrations/aws.mdx
@@ -133,7 +133,7 @@ The CloudFormation-created IAM role includes **read-only** access to:
 - Lambda, ECS, and other compute services
 - Cost Explorer, Budgets, Compute Optimizer, and Trusted Advisor (cost and usage data, recommendations)
 
-Write permissions are limited to VPC Flow Log management (creating/deleting flow log configurations) and the cost-remediation actions (`ec2:StopInstances`, `ec2:DeleteVolume`, `ec2:ReleaseAddress`, `ec2:DeleteSnapshot`) used by the Cloud Cost remediation workflow blocks.
+Write permissions are limited to VPC Flow Log management (creating/deleting flow log configurations) and the cost-remediation actions (`ec2:StopInstances`, `ec2:DeleteVolume`, `ec2:ReleaseAddress`, `ec2:DeleteSnapshot`, plus `ec2:CreateSnapshot` for pre-deletion safety snapshots) used by the Cloud Cost remediation workflow blocks.
 
 <Note>
   If you connected your account before the cost-optimization blocks were released, update your CloudFormation stack to the latest template to grant the new Cost Explorer, Budgets, Compute Optimizer, and remediation permissions. Blocks that lack permissions fail with an actionable error pointing at the stack update.

--- a/docs/integrations/aws.mdx
+++ b/docs/integrations/aws.mdx
@@ -93,6 +93,16 @@ You can enable/disable flow logs on individual VPCs.
 - **Any AWS Cloud Incident** — fires on any AWS cloud incident detected by Kestrel
 - **Cost Anomaly Detected** — fires when AWS Cost Anomaly Detection identifies unusual spend
 - **Budget Threshold Exceeded** — fires when an AWS Budget threshold is breached
+- **Forecast Exceeds Budget** — fires when the Cost Explorer forecast projects a budget overrun before it happens
+- **Spend Spike Detected** — fires when day-over-day spend rises beyond a configurable percentage threshold
+- **Idle Resource Detected** — fires when a daily scan finds idle resources (unattached EBS volumes, unassociated Elastic IPs, low-CPU instances, old snapshots)
+
+**Cost optimization action blocks:**
+
+Connected accounts unlock the Cloud Cost action blocks in workflows:
+
+- *Insights (read-only)*: Query Cost Explorer, Get Cost Anomalies, Get Cost Forecast, Get Budget Status, Get Rightsizing Recommendations, Get Savings Plans Recommendations, Get Reservation Recommendations, Get Commitment Utilization, Compare Cost Periods, Find Idle Resources, Get Compute Optimizer Recommendations, Get Trusted Advisor Cost Checks
+- *Remediation (mutates infrastructure — place behind an Approval block)*: Stop EC2 Instances, Delete Unattached EBS Volumes, Release Elastic IPs, Delete Old Snapshots. Resources tagged `kestrel:protected` are always skipped.
 
 Cloud operations (querying resources, describing instances, checking security groups, generating Terraform fixes, creating IaC remediation PRs) are provided by Kestrel's built-in action blocks and are available in any workflow alongside these triggers.
 
@@ -121,8 +131,13 @@ The CloudFormation-created IAM role includes **read-only** access to:
 - CloudTrail (event history)
 - EKS (clusters, node groups)
 - Lambda, ECS, and other compute services
+- Cost Explorer, Budgets, Compute Optimizer, and Trusted Advisor (cost and usage data, recommendations)
 
-Write permissions are limited to VPC Flow Log management (creating/deleting flow log configurations).
+Write permissions are limited to VPC Flow Log management (creating/deleting flow log configurations) and the cost-remediation actions (`ec2:StopInstances`, `ec2:DeleteVolume`, `ec2:ReleaseAddress`, `ec2:DeleteSnapshot`) used by the Cloud Cost remediation workflow blocks.
+
+<Note>
+  If you connected your account before the cost-optimization blocks were released, update your CloudFormation stack to the latest template to grant the new Cost Explorer, Budgets, Compute Optimizer, and remediation permissions. Blocks that lack permissions fail with an actionable error pointing at the stack update.
+</Note>
 
 ## Managing Connections
 

--- a/docs/workflows/create-workflows.mdx
+++ b/docs/workflows/create-workflows.mdx
@@ -128,6 +128,19 @@ Triggered when Kestrel detects a cloud infrastructure incident. Filter by AWS ac
 | Any AWS Cloud Incident | Triggers on any AWS cloud incident |
 | Cost Anomaly Detected | Triggers when AWS Cost Anomaly Detection finds an anomaly |
 | Budget Threshold Exceeded | Triggers when an AWS Budget threshold is breached |
+| Forecast Exceeds Budget | Triggers when the AWS cost forecast projects a budget overrun before it happens |
+| Spend Spike Detected | Triggers when day-over-day spend rises beyond a configurable percentage threshold |
+| Idle Resource Detected | Triggers when a daily scan finds idle resources (unattached EBS volumes, unassociated Elastic IPs, low-CPU instances, old snapshots) |
+
+### Schedule
+
+Triggered on a recurring cadence rather than by an external event. Ideal for periodic cost reports, cleanup scans, and audits. Configure the interval (hourly, daily, weekly, or monthly), the time of day (UTC), and — for weekly/monthly schedules — the day of week or day of month.
+
+| Trigger Block | Description |
+|---|---|
+| Recurring Schedule | Triggers on a recurring schedule (hourly, daily, weekly, or monthly) |
+
+Scheduled triggers expose `{{signal.schedule_interval}}`, `{{signal.fired_at}}`, and `{{signal.fired_date}}` to downstream steps.
 
 ### Slack Requests
 
@@ -321,8 +334,8 @@ Actions are grouped by integration. Each action produces output variables that d
   <Card title="Datadog" icon="chart-line">
     Query Metrics, Create Monitor, Send Event, Mute Monitor
   </Card>
-  <Card title="Cloud Cost" icon="dollar-sign">
-    Query Cost Explorer, Get Cost Anomalies, Get Cost Forecast, Get Budget Status
+  <Card title="Cloud Cost" icon="aws">
+    Query Cost Explorer, Get Cost Anomalies, Get Cost Forecast, Get Budget Status, Get Rightsizing Recommendations, Get Savings Plans Recommendations, Get Reservation Recommendations, Get Commitment Utilization, Compare Cost Periods, Find Idle Resources, Get Compute Optimizer Recommendations, Get Trusted Advisor Cost Checks, Stop EC2 Instances, Delete Unattached EBS Volumes, Release Elastic IPs, Delete Old Snapshots
   </Card>
   <Card title="PostHog" icon="chart-bar">
     Get Session Summary, Get Session Recording, Query Events, List Session Recordings, Get Error Issue
@@ -352,6 +365,10 @@ Actions are grouped by integration. Each action produces output variables that d
     Create custom action blocks to call any API endpoint, and custom webhook triggers to start workflows from external systems. See [Custom Integrations](/workflows/custom-integrations).
   </Card>
 </CardGroup>
+
+<Warning>
+The Cloud Cost remediation blocks (**Stop EC2 Instances**, **Delete Unattached EBS Volumes**, **Release Elastic IPs**, **Delete Old Snapshots**) mutate real infrastructure. Always place them behind an [Approval Gate](#approval-gates). Resources tagged `kestrel:protected` are always skipped, every remediation block is pinned to an explicit region, and safety caps limit how many resources a single run can touch.
+</Warning>
 
 ---
 
@@ -421,6 +438,10 @@ Template variables let you pass data between workflow steps. Use double curly br
 | `{{signal.deployment_id}}` | Pulumi Cloud trigger | Pulumi Deployments run ID (deployment events) |
 | `{{signal.update_url}}` | Pulumi Cloud trigger | Link to the update in the Pulumi Cloud console |
 | `{{signal.user}}` | Pulumi Cloud trigger | User who initiated the operation |
+| `{{signal.aws_account_id}}` | AWS cost trigger | AWS account ID for cost anomaly, budget, forecast, spend spike, and idle resource signals |
+| `{{signal.schedule_interval}}` | Schedule trigger | Configured cadence (hourly, daily, weekly, monthly) |
+| `{{signal.fired_at}}` | Schedule trigger | UTC timestamp (RFC3339) when the schedule fired |
+| `{{signal.fired_date}}` | Schedule trigger | UTC date (YYYY-MM-DD) when the schedule fired |
 
 ### Variable Picker
 
@@ -664,6 +685,43 @@ On **Request changes**, the reviewer's free-text guidance re-runs the RCA agent 
 | **Action 1** | Query Cost Explorer | Account: `{{signal.aws_account_id}}`, time range: 7 days |
 | **Action 2** | AI Cost Analysis | Type: anomaly |
 | **Action 3** | Slack Send Message | Channel: `#finops`, message: `{{step_outputs.action-2.summary}}` |
+
+### Weekly Schedule → Cost Report → Savings Recommendations → Slack
+
+**Workflow Agent prompt:** *"Every Monday at 9am UTC, query last week's AWS costs grouped by service, get savings plans recommendations, run an AI cost analysis, and post an executive summary to #finops in Slack."*
+
+| Step | Type | Configuration |
+|------|------|---------------|
+| **Trigger** | Recurring Schedule | Weekly, Monday, 09:00 UTC |
+| **Action 1** | Query Cost Explorer | Time range: 7 days, group by: Service |
+| **Action 2** | Get Savings Plans Recommendations | Term: 1 year, payment: no upfront |
+| **Action 3** | AI Cost Analysis | Type: summary |
+| **Action 4** | Slack Send Message | Channel: `#finops`, message: `{{step_outputs.action-3.formatted_slack_message}}` |
+
+### Idle Resource Scan → Approval → Cleanup → Slack
+
+**Workflow Agent prompt:** *"Every day at 8am UTC, scan for idle resources (unattached EBS volumes and unassociated Elastic IPs), ask for approval in #finops, and if approved delete the unattached volumes (snapshot first) and release the idle Elastic IPs."*
+
+| Step | Type | Configuration |
+|------|------|---------------|
+| **Trigger** | Recurring Schedule | Daily, 08:00 UTC |
+| **Action 1** | Find Idle Resources | Resource types: EBS volumes, Elastic IPs; all enabled regions |
+| **Action 2** | Wait for Slack Approval | Channel: `#finops`, message includes `{{step_outputs.action-1.idle_count}}` idle resources, est. savings `{{step_outputs.action-1.estimated_monthly_savings}}` |
+| **On Approved → Action 3** | Delete Unattached EBS Volumes | Volume IDs: `{{step_outputs.action-1.idle_volume_ids}}`, snapshot first |
+| **On Approved → Action 4** | Release Elastic IPs | Allocation IDs: `{{step_outputs.action-1.idle_eip_allocation_ids}}` |
+| **Action 5** | Slack Send Message | Channel: `#finops`, message: cleanup summary |
+
+### Forecast Overrun → Compare Periods → Rightsizing → Slack
+
+**Workflow Agent prompt:** *"When the AWS cost forecast projects a budget overrun, compare this month's spend to last month to find the biggest movers, get rightsizing recommendations, and post the analysis to #finops in Slack."*
+
+| Step | Type | Configuration |
+|------|------|---------------|
+| **Trigger** | Forecast Exceeds Budget | All AWS accounts |
+| **Action 1** | Compare Cost Periods | This month vs last month, group by: Service |
+| **Action 2** | Get Rightsizing Recommendations | All recommendation types |
+| **Action 3** | AI Cost Analysis | Type: optimization |
+| **Action 4** | Slack Send Message | Channel: `#finops`, message: `{{step_outputs.action-3.summary}}` |
 
 ---
 

--- a/docs/workflows/sdk.mdx
+++ b/docs/workflows/sdk.mdx
@@ -127,9 +127,18 @@ Trigger.aws_service_health()
 # AWS — Cost & Budget
 Trigger.aws_cost_anomaly()
 Trigger.aws_budget_alert()
+Trigger.aws_forecast_overrun()            # forecast projects a budget overrun
+Trigger.aws_spend_spike()                 # day-over-day spend spike
+Trigger.aws_idle_resource()               # daily idle-resource scan hit
 
 # AWS — Catch-all
 Trigger.aws_any()
+
+# Schedule (recurring workflows — no external event needed)
+Trigger.schedule_hourly()                                  # fires every hour
+Trigger.schedule_daily("09:00")                            # daily at 09:00 UTC
+Trigger.schedule_weekly(day_of_week=1, time_utc="09:00")   # Mondays 09:00 UTC (0=Sunday)
+Trigger.schedule_monthly(day_of_month=1, time_utc="06:00") # 1st of month 06:00 UTC
 
 # PagerDuty
 Trigger.pagerduty_triggered()
@@ -468,11 +477,31 @@ Action.helm_rollback().cluster_id("...").release_name("my-app").namespace("produ
 Action.helm_uninstall().cluster_id("...").release_name("my-app").namespace("production")
 Action.helm_status().cluster_id("...").release_name("my-app").namespace("production")
 
-# AWS Cost
+# AWS Cost — insights (read-only)
 Action.aws_query_cost_explorer().aws_account("123456789012").time_range("30d")
 Action.aws_get_cost_anomalies().aws_account("123456789012")
 Action.aws_get_cost_forecast().aws_account("123456789012")
 Action.aws_get_budget_status().aws_account("123456789012")
+Action.aws_get_rightsizing_recommendations().aws_account("123456789012")
+Action.aws_get_savings_plans_recommendations().aws_account("123456789012")
+Action.aws_get_reservation_recommendations().aws_account("123456789012")
+Action.aws_get_commitment_utilization().aws_account("123456789012")
+Action.aws_compare_cost_periods().aws_account("123456789012")
+Action.aws_find_idle_resources().aws_account("123456789012")
+Action.aws_get_compute_optimizer_recommendations().aws_account("123456789012")
+Action.aws_get_trusted_advisor_cost_checks().aws_account("123456789012")
+
+# AWS Cost — remediation (destructive; place behind an Approval block.
+# Resources tagged kestrel:protected are always skipped.)
+Action.aws_stop_ec2_instances().aws_account("123456789012") \
+    .config("instance_ids", "{{step_outputs.scan.idle_instance_ids}}").config("region", "us-east-1")
+Action.aws_delete_unattached_ebs_volumes().aws_account("123456789012") \
+    .config("volume_ids", "{{step_outputs.scan.idle_volume_ids}}").config("region", "us-east-1") \
+    .config("snapshot_first", True)
+Action.aws_release_elastic_ips().aws_account("123456789012") \
+    .config("allocation_ids", "{{step_outputs.scan.idle_eip_allocation_ids}}").config("region", "us-east-1")
+Action.aws_delete_old_snapshots().aws_account("123456789012") \
+    .config("region", "us-east-1").config("age_days", 90)
 
 # PostHog
 Action.posthog_get_session_summary().session_ids("{{signal.session_id}}")

--- a/docs/workflows/setup-integrations.mdx
+++ b/docs/workflows/setup-integrations.mdx
@@ -20,7 +20,7 @@ Prefer the terminal? Every integration can also be connected with the [Kestrel C
     **Triggers:** Deployment Replicas Failing, Pod CrashLoopBackOff, Pod ImagePullBackOff, Pod OOMKilled, Pods Failing, Pods Restarting, StatefulSet Replicas Failing, Node Memory/Disk Pressure, DaemonSet Failing, and more. **Actions:** Trigger K8s RCA & Generate Fix, Apply YAML Fix, Generate K8s Manifest, Apply K8s Manifest, Investigate Kubernetes.
   </Card>
   <Card title="AWS" icon="aws" href="/integrations/aws">
-    **Triggers:** IAM Security Event, Root Account Activity, S3 Bucket Change, EC2/Lambda/RDS/DynamoDB Issues, VPC/Network Change, CloudWatch Alarm, Cost Anomaly, Budget Threshold, and more. **Actions:** Trigger Cloud RCA & Generate Fix, Generate Cloud Resource (Terraform/CloudFormation/CLI), Execute Cloud CLI, Query Cost Explorer, Get Cost Anomalies/Forecast/Budget Status, Investigate Cloud.
+    **Triggers:** IAM Security Event, Root Account Activity, S3 Bucket Change, EC2/Lambda/RDS/DynamoDB Issues, VPC/Network Change, CloudWatch Alarm, Cost Anomaly, Budget Threshold, Forecast Overrun, Spend Spike, Idle Resource, and more. **Actions:** Trigger Cloud RCA & Generate Fix, Generate Cloud Resource (Terraform/CloudFormation/CLI), Execute Cloud CLI, Query Cost Explorer, Get Cost Anomalies/Forecast/Budget Status, Rightsizing/Savings Plans/Reservation Recommendations, Find Idle Resources, Cost Remediation (Stop EC2, Delete EBS Volumes, Release EIPs, Delete Snapshots), Investigate Cloud.
   </Card>
   <Card title="OCI" icon="cloud" href="/integrations/oci">
     Connect Oracle Cloud Infrastructure for resource inventory and incident detection.
@@ -131,7 +131,16 @@ Prefer the terminal? Every integration can also be connected with the [Kestrel C
 
 ## Cost Management
 
-AWS Cost features (Query Cost Explorer, Get Cost Anomalies, Get Cost Forecast, Get Budget Status, AI Cost Analysis) are available through the [AWS integration](/integrations/aws). No separate setup is required — cost management actions are enabled when you connect an AWS account.
+AWS Cost features are available through the [AWS integration](/integrations/aws). No separate setup is required — cost management actions are enabled when you connect an AWS account.
+
+- **Insights (read-only):** Query Cost Explorer, Get Cost Anomalies, Get Cost Forecast, Get Budget Status, Get Rightsizing Recommendations, Get Savings Plans Recommendations, Get Reservation Recommendations, Get Commitment Utilization, Compare Cost Periods, Find Idle Resources, Get Compute Optimizer Recommendations, Get Trusted Advisor Cost Checks, AI Cost Analysis
+- **Remediation (destructive — place behind an Approval block):** Stop EC2 Instances, Delete Unattached EBS Volumes, Release Elastic IPs, Delete Old Snapshots
+- **Cost triggers:** Cost Anomaly Detected, Budget Threshold Exceeded, Forecast Exceeds Budget, Spend Spike Detected, Idle Resource Detected
+- **Scheduled workflows:** combine the [Recurring Schedule trigger](/workflows/create-workflows#schedule) with cost actions for periodic reports and cleanup scans
+
+<Note>
+Accounts connected before the cost-optimization release need a CloudFormation stack update to grant the new Cost Explorer, Budgets, Compute Optimizer, and remediation IAM permissions.
+</Note>
 
 ## Knowledge Sources
 


### PR DESCRIPTION
## Summary
- Document the new AWS cost optimization workflow blocks: 10 read-only insight actions (rightsizing, savings plans / reservation recommendations, commitment utilization, cost period comparison, idle resource scan, Compute Optimizer, Trusted Advisor) and 4 approval-guarded remediation actions (stop EC2 instances, delete unattached EBS volumes, release Elastic IPs, delete old snapshots).
- Document the new AWS cost triggers (Forecast Exceeds Budget, Spend Spike Detected, Idle Resource Detected) and the new Recurring Schedule trigger (hourly / daily / weekly / monthly).
- Add new template variables (`signal.aws_account_id`, `signal.schedule_interval`, `signal.fired_at`, `signal.fired_date`), updated IAM permissions for the CloudFormation stack, SDK trigger/action builders, and three end-to-end FinOps example workflows.

## Test plan
- [ ] Docs preview renders correctly (Mintlify components: Card, Warning, Note)
- [ ] Block names and template variables match the shipped server catalog

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Expanded AWS “In Workflows” with new Cloud Cost triggers (forecast/budget overrun, spend spikes, idle resource detection) and added Schedule trigger coverage with exposed template variables.
  * Expanded AWS Cloud Cost action cards with a larger set of insights (read-only) and new remediation examples (destructive) for cost optimization.
  * Strengthened safety guidance by highlighting the need for an Approval Gate for destructive actions and clarifying protected-resource handling.
  * Updated IAM permissions coverage and added guidance for upgrading existing connections via stack updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->