### PR TITLE
Remove global og:title/og:description overrides from docs metadata

### DIFF
--- a/docs/mint.json
+++ b/docs/mint.json
@@ -173,8 +173,6 @@
     "prompt": "Search documentation..."
   },
   "metadata": {
-    "og:title": "Kestrel AI Documentation",
-    "og:description": "AI Agents for Platform Engineering. Automate incident response, cloud provisioning, CI/CD, and more with intelligent workflows.",
     "og:image": "https://usekestrel.ai/og-image.png",
     "twitter:card": "summary_large_image"
   },


### PR DESCRIPTION
Let each docs page use its own title/description for SEO instead of a single site-wide Open Graph title and description.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Reduced the set of page metadata included in the site docs configuration.
  * Open Graph title and description fields are no longer provided, leaving image and social card metadata in place.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->