### PR TITLE
docs: document new Daytona Create Sandbox and Create/Delete Volume workflow blocks

### DIFF
--- a/docs/integrations/daytona.mdx
+++ b/docs/integrations/daytona.mdx
@@ -67,6 +67,7 @@ Filter triggers by sandbox and event type. Kestrel receives these as webhook del
 
 **Action blocks:**
 - **List Sandboxes** — list the sandboxes in the organization
+- **Create Sandbox** — create a sandbox from a prebuilt snapshot or a Docker image (image references must carry a specific version tag or digest, e.g. `python:3.12` — untagged images and `latest`/`lts`/`stable` are rejected by Daytona)
 - **Get Sandbox** — retrieve a sandbox's state and metadata
 - **Start Sandbox** — start a stopped sandbox
 - **Stop Sandbox** — stop a running sandbox (preserves state for restart)
@@ -75,13 +76,15 @@ Filter triggers by sandbox and event type. Kestrel receives these as webhook del
 - **Run Command in Sandbox** — execute a shell command in a sandbox and capture exit code and output
 - **Set Auto-Stop Interval** — set a sandbox's inactivity auto-stop interval for cost control
 - **List Snapshots** — list the snapshots in the organization
-- **Create Snapshot** — create a snapshot from a Docker image
+- **Create Snapshot** — create a snapshot from a Docker image (the image must carry a specific version tag or digest)
 - **Delete Snapshot** — delete a snapshot by name or ID
 - **List Volumes** — list the volumes in the organization
 - **Get Volume** — retrieve a volume's state
+- **Create Volume** — create a volume for sharing data across sandboxes
+- **Delete Volume** — permanently delete a volume (gate behind an Approval node)
 - **Investigate Daytona** — run an AI investigation of failing sandboxes, snapshots, and volumes
 
-Daytona sandbox, snapshot, and volume selects accept template variables like `{{signal.sandbox_id}}`, `{{signal.snapshot}}`, and `{{signal.volume}}` from the trigger.
+Daytona sandbox, snapshot, and volume selects accept template variables like `{{signal.sandbox_id}}`, `{{signal.snapshot}}`, and `{{signal.volume}}` from the trigger. Create Sandbox outputs `sandbox_id`, `sandbox_name`, and `sandbox_state`, so downstream blocks can reference a just-created sandbox with `{{step_outputs.<step>.sandbox_id}}`; Create Volume similarly outputs `volume_id`, `volume_name`, and `volume_state`.
 
 Example: A workflow triggers on a sandbox error, runs an AI investigation to diagnose the failure, posts a summary to Slack, and opens a Jira bug ticket.
 

--- a/docs/workflows/setup-integrations.mdx
+++ b/docs/workflows/setup-integrations.mdx
@@ -113,7 +113,7 @@ Prefer the terminal? Every integration can also be connected with the [Kestrel C
     **Triggers (poll-based):** GPU Error, Maintenance Scheduled, Node Not Ready, Instance Stopped. **Actions:** Get Instance, Start Instance, Stop Instance, Restart Instance, List Instances, List Clusters, List Node Groups, Scale Node Group, Investigate Nebius.
   </Card>
   <Card title="Daytona" icon="cube" href="/integrations/daytona">
-    **Triggers (webhook):** Sandbox Created, Sandbox Stopped, Sandbox Error, Sandbox Archived, Sandbox Execution Failed, Snapshot Build Failed, Volume Error. **Actions:** List/Get/Start/Stop/Archive/Delete Sandbox, Run Command, Set Auto-Stop, List/Create/Delete Snapshot, List/Get Volume, Investigate Daytona.
+    **Triggers (webhook):** Sandbox Created, Sandbox Stopped, Sandbox Error, Sandbox Archived, Sandbox Execution Failed, Snapshot Build Failed, Volume Error. **Actions:** List/Create/Get/Start/Stop/Archive/Delete Sandbox, Run Command, Set Auto-Stop, List/Create/Delete Snapshot, List/Get/Create/Delete Volume, Investigate Daytona.
   </Card>
   <Card title="Supabase" icon="database" href="/integrations/supabase">
     **Triggers (poll-based + webhook):** Project Health Degraded, Backup Failed, Read Replica Unhealthy, Usage/Quota Threshold, Branch Created, Branch Migration Failed (poll-based), Database Row Event (Database Webhook). **Actions:** List/Get Project, Get Project Health, Create/List/Get/Merge/Reset/Delete Branch, List Backups, Create Restore Point, Restore Backup (PITR), Setup/Remove Read Replica, Pause/Restore Project, Get/Update Network Restrictions, List API Keys, Investigate Supabase.


### PR DESCRIPTION
## Summary
- Document the new **Create Sandbox** action block (snapshot or Docker image, with the specific-version-tag/digest requirement Daytona enforces)
- Document the new **Create Volume** and **Delete Volume** action blocks
- Note Create Snapshot's image tag/digest requirement and the template variables the new blocks output (`sandbox_id`, `volume_id`, etc.)
- Update the Daytona card in setup-integrations to list the new actions

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified Daytona integration guidance for action blocks, including stricter image and snapshot version requirements.
  * Added clearer notes on approved deletion steps and which trigger variables can be used in sandbox and volume settings.
  * Documented the outputs available from sandbox and volume creation for use in later workflow steps.
  * Updated the Daytona integration overview to reflect a broader set of supported sandbox and volume actions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->