### PR TITLE
docs: document the Poll Until (loop) workflow block

### DIFF
--- a/docs/workflows/create-workflows.mdx
+++ b/docs/workflows/create-workflows.mdx
@@ -504,6 +504,29 @@ The loop repeats until you approve or reject, capped by **Max Refine Rounds** (d
 
 ---
 
+## Poll Until (Loops)
+
+The **Poll Until** block (Flow Control) repeatedly runs a single catalog action at a fixed interval and evaluates an exit condition against each iteration's output. It's the building block for "wait for X to reach state Y" automation — waiting for a sandbox to stop, a deployment to become healthy, a pipeline to finish, or a cloud resource to reach a target state.
+
+Drag **Poll Until** from the sidebar (next to Conditions) onto the canvas, then configure:
+
+- **Action to Poll** — any catalog action (searchable dropdown). Its config fields appear below and behave exactly like the standalone action block, including dynamic dropdowns (e.g. Cluster → Namespace scoping) and template variables.
+- **Output Field Path** — which output field of the polled action to test, chosen from the action's known outputs.
+- **Operator + Value** — `equals`, `not_equals`, `contains`, `not_contains`, `exists`, `not_exists`. Where the output has known discrete values (states, statuses) or refers to live resources (cluster IDs), the Value field is a dropdown. You can select **multiple values**: `equals`/`contains` are met when the output matches ANY selected value; `not_equals`/`not_contains` are met only when it matches NONE.
+- **Poll Interval** — how often to re-run the action (default 60s, minimum 30s).
+- **Timeout** — how long to keep polling (default 60 minutes).
+
+The block has two outgoing branches:
+
+- **met** — the exit condition held on some iteration; downstream steps see the final iteration's output.
+- **timeout** — the timeout elapsed before the condition was met.
+
+<Note>
+Polling is durable. The loop's schedule is persisted server-side, so a server restart mid-interval resumes the countdown where it left off instead of restarting the interval — and in-flight loops survive redeployments.
+</Note>
+
+---
+
 ## Generating Runbooks
 
 The **Generate Runbook** action (Kestrel) distills a completed RCA and its fixes into a reusable, generalized runbook for that *class* of incident — symptom, diagnosis steps, remediation steps, verification, and rollback. It requires an upstream RCA step. The generated runbook is available to downstream steps as `{{runbook_html}}` / `{{runbook_markdown}}`, and **Publish Runbook Entry** (Confluence) consumes `runbook_html` automatically.

--- a/docs/workflows/sdk.mdx
+++ b/docs/workflows/sdk.mdx
@@ -44,7 +44,7 @@ Build workflows using typed classes with full IDE autocompletion:
 
 ```python
 from kestrel import KestrelClient
-from kestrel.workflows import Workflow, Trigger, Action, Condition, Approval
+from kestrel.workflows import Workflow, Trigger, Action, Condition, Approval, PollUntil
 
 wf = (
     Workflow("Pod Crash RCA + Jira")
@@ -403,6 +403,8 @@ Action.kestrel_create_iac_pr().repo("org/infra-repo")
 
 # Kestrel — Flow Control
 Action.kestrel_wait().duration(5).unit("minutes")
+PollUntil(Action.daytona_get_sandbox().sandbox_id("{{signal.sandbox_id}}"),
+          Condition.equals("sandbox_state", "stopped")).every(seconds=60).timeout(minutes=30)
 
 # Slack
 Action.slack_send_message().channel("incidents").message("{{incident.title}}").include_rca(True)
@@ -627,6 +629,41 @@ wf = (
 ```
 
 Available operators: `equals`, `not_equals`, `contains`, `not_contains`, `exists`, `not_exists`.
+
+The value-comparing factories accept multiple candidate values — `equals`/`contains` are met when the field matches **any** value, `not_equals`/`not_contains` only when it matches **none**:
+
+```python
+Condition.equals("sandbox_state", "stopped", "error")       # met if stopped OR error
+Condition.not_equals("phase", "Failed", "Degraded")         # met only if neither
+```
+
+### Poll Until (Loops)
+
+`PollUntil` builds a self-looping node that repeatedly executes ONE embedded catalog action at a fixed interval and exits on the **met** branch when the condition holds against that iteration's output, or on the **timeout** branch when the timeout elapses. Wire the branches with `.on_met()` / `.on_timeout()`:
+
+```python
+wf = (
+    Workflow("Snapshot stopped sandbox")
+    .trigger(Trigger.custom_webhook("sandbox.watch"))
+    .then(
+        PollUntil(
+            Action.daytona_get_sandbox().sandbox_id("{{signal.sandbox_id}}"),
+            Condition.equals("sandbox_state", "stopped", "error"),
+        )
+        .every(seconds=60)
+        .timeout(minutes=30)
+        .label("Poll until sandbox stops")
+    )
+    .on_met(Action.daytona_create_snapshot().name("post-stop-{{signal.sandbox_id}}"))
+    .on_timeout(Action.slack_send_message().channel("ops").message("Sandbox never stopped"))
+)
+```
+
+- `.every(seconds=..., minutes=...)` — polling interval (default 60s, minimum 30s).
+- `.timeout(minutes=..., hours=...)` — loop timeout (default 60 minutes).
+- Downstream steps on the **met** branch can reference the final iteration's output fields via `{{step_outputs.<loop-id>.<field>}}`.
+
+Polling is durable across server restarts: an in-flight interval resumes its countdown rather than restarting.
 
 ### Approvals
 


### PR DESCRIPTION
## Summary
- Adds a **Poll Until (Loops)** section to the workflow creation guide covering block configuration (action to poll, output field path, operator + multi-value Value dropdown, interval, timeout), the met/timeout branches, and durable server-side polling that survives restarts.
- Documents the Python SDK's `PollUntil` builder: `.every()` / `.timeout()`, `.on_met()` / `.on_timeout()` wiring, referencing loop outputs via `{{step_outputs.<loop-id>.<field>}}`, plus the multi-value `Condition` factories (ANY-match for `equals`/`contains`, NONE-match for the negated operators).

## Test plan
- [ ] Docs preview renders the new sections in `create-workflows.mdx` and `sdk.mdx` correctly
- [ ] SDK code examples match kestrel-workflows v0.35.0 API

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance for the “Poll Until (Loops)” flow control block, including how to configure polling, exit conditions, interval, timeout, and branch outcomes.
  * Expanded SDK docs with a complete polling example and clearer guidance on handling multiple values, final results, and default polling behavior.
  * Documented that polling is durable and can resume after restarts or redeployments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->