### PR TITLE
docs: document Nebius provisioning blocks

### DIFF
--- a/docs/integrations/nebius.mdx
+++ b/docs/integrations/nebius.mdx
@@ -75,11 +75,19 @@ Filter triggers by project, cluster, and event type. Kestrel polls the Nebius AP
 - **List Clusters** — list managed Kubernetes clusters for a project
 - **List Node Groups** — list node groups for a managed Kubernetes cluster
 - **Scale Node Group** — scale a node group to a target size
+- **Create Instance** — provision a new GPU or CPU instance with its boot disk (platform, preset, subnet, image, disk size, optional SSH key)
+- **Delete Instance** — delete an instance and, by default, its boot disk
+- **Create Node Group** — provision a new GPU/CPU worker pool in a managed Kubernetes cluster
+- **Delete Node Group** — delete a node group, tearing down its nodes
 - **Investigate Nebius** — run an AI investigation of GPU errors, node failures, and configuration issues
 
 Nebius project, instance, cluster, and node-group selects accept template variables like `{{signal.project_id}}`, `{{signal.instance_id}}`, `{{signal.cluster_id}}`, and `{{signal.node_name}}` from the trigger.
 
+Provisioning and deletion blocks (Create/Delete Instance, Create/Delete Node Group) create or destroy billable GPU capacity — gate them behind an Approval node in production workflows. Create Instance outputs an `instance_id` that downstream blocks can reference via `{{step_outputs.<id>.instance_id}}`.
+
 Example: A workflow triggers on a GPU error, runs an AI investigation to diagnose the failure, scales the affected node group to replace the bad node, and posts a summary to Slack.
+
+Example: A developer requests an H100 instance via Slack (`req-nebius` trigger); the workflow waits for approval, provisions the instance with Create Instance, and DMs the requester the new instance ID.
 
 ## Disconnecting
 

--- a/docs/integrations/nebius.mdx
+++ b/docs/integrations/nebius.mdx
@@ -83,7 +83,7 @@ Filter triggers by project, cluster, and event type. Kestrel polls the Nebius AP
 
 Nebius project, instance, cluster, and node-group selects accept template variables like `{{signal.project_id}}`, `{{signal.instance_id}}`, `{{signal.cluster_id}}`, and `{{signal.node_name}}` from the trigger.
 
-Provisioning and deletion blocks (Create/Delete Instance, Create/Delete Node Group) create or destroy billable GPU capacity — gate them behind an Approval node in production workflows. Create Instance outputs an `instance_id` that downstream blocks can reference via `{{step_outputs.<id>.instance_id}}`.
+Provisioning and deletion blocks (Create/Delete Instance, Create/Delete Node Group) create or destroy billable GPU capacity; add an Approval node before them if you want a human sign-off step. Create Instance outputs an `instance_id` that downstream blocks can reference via `{{step_outputs.<id>.instance_id}}`.
 
 Example: A workflow triggers on a GPU error, runs an AI investigation to diagnose the failure, scales the affected node group to replace the bad node, and posts a summary to Slack.
 

--- a/docs/workflows/setup-integrations.mdx
+++ b/docs/workflows/setup-integrations.mdx
@@ -113,7 +113,7 @@ Prefer the terminal? Every integration can also be connected with the [Kestrel C
     **Triggers (poll-based):** Machine Crashed, Machine Stopped, Machine Started, App Down. **Actions:** Restart Machine, Start Machine, Stop Machine, Suspend Machine, Cordon Machine, Uncordon Machine, Get Machine, Get Machine Events, List Machines, Set Secrets, Investigate Fly.
   </Card>
   <Card title="Nebius AI Cloud" icon="microchip" href="/integrations/nebius">
-    **Triggers (poll-based):** GPU Error, Maintenance Scheduled, Node Not Ready, Instance Stopped. **Actions:** Get Instance, Start Instance, Stop Instance, Restart Instance, List Instances, List Clusters, List Node Groups, Scale Node Group, Investigate Nebius.
+    **Triggers (poll-based):** GPU Error, Maintenance Scheduled, Node Not Ready, Instance Stopped. **Actions:** Get Instance, Start Instance, Stop Instance, Restart Instance, Create Instance, Delete Instance, List Instances, List Clusters, List Node Groups, Scale Node Group, Create Node Group, Delete Node Group, Investigate Nebius.
   </Card>
   <Card title="Daytona" icon="cube" href="/integrations/daytona">
     **Triggers (webhook):** Sandbox Created, Sandbox Stopped, Sandbox Error, Sandbox Archived, Sandbox Execution Failed, Snapshot Build Failed, Volume Error. **Actions:** List/Create/Get/Start/Stop/Archive/Delete Sandbox, Run Command, Set Auto-Stop, List/Create/Delete Snapshot, List/Get/Create/Delete Volume, Investigate Daytona.


### PR DESCRIPTION
## Summary
- Document the four new Nebius provisioning action blocks (Create Instance, Delete Instance, Create Node Group, Delete Node Group) on the Nebius integration page
- Add approval-gating guidance and `{{step_outputs.<id>.instance_id}}` chaining note for provisioning/deletion blocks
- Add a developer-request example (Slack `req-nebius` → approval → Create Instance)
- Update the Nebius card in the setup-integrations guide with the new actions

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Expanded the Nebius AI Cloud integration docs with additional workflow actions, covering instance creation/deletion and node group creation/deletion (along with existing scaling/investigation guidance).
  * Added guidance for production workflows to gate billable GPU provisioning/deprovisioning behind an approval step.
  * Clarified that the “Create Instance” step outputs an `instance_id` for use in later steps.
  * Updated the workflow example to include an approval-based request flow alongside the existing GPU error → diagnosis → scaling example.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->