### PR TITLE
docs: document the For Each (fan-out) workflow block

### DIFF
--- a/docs/workflows/create-workflows.mdx
+++ b/docs/workflows/create-workflows.mdx
@@ -527,6 +527,28 @@ Polling is durable. The loop's schedule is persisted server-side, so a server re
 
 ---
 
+## For Each (Fan-Out)
+
+The **For Each** block (Flow Control) resolves a list from an upstream step's output at runtime and runs a single catalog action once per element, in order. It's the building block for "do X for every Y" automation — creating a Jira ticket for each new audit finding, sending a message per failed service, or opening an issue for every flagged resource — without knowing the number of items in advance.
+
+Drag **For Each** from the sidebar (Flow Control) onto the canvas, then configure:
+
+- **Items to Iterate Over** — a template that resolves to a list, e.g. `{{step_outputs.action-1.outputs.new_findings}}` from an Execute Script step that wrote an array to its outputs. JSON-encoded array strings and comma-separated strings also work.
+- **Action per Item** — any catalog action (searchable dropdown). Its config fields appear below and behave exactly like the standalone action block. Inside these fields, three extra template variables are available:
+  - `{{item}}` — the current element (rendered as JSON when it's an object)
+  - `{{item.<field>}}` — a field of the current element, e.g. `{{item.title}}`
+  - `{{item_index}}` — the zero-based index of the current element
+- **Max Items** — caps the fan-out (default 25, hard cap 100). Extra items are skipped and the aggregated output is marked `truncated`.
+- **Continue on Error** — when enabled, a failed item doesn't fail the whole block; remaining items still run.
+
+The block emits **one aggregated output**: `items_total`, `items_processed`, `succeeded`, `failed`, per-item `results`, and a flat `summary` string usable in downstream templates. Its outgoing edges fire after **all** items have been processed.
+
+<Note>
+For Each runs items once each, immediately and sequentially. To repeatedly re-run an action until a condition holds, use **Poll Until** instead.
+</Note>
+
+---
+
 ## Generating Runbooks
 
 The **Generate Runbook** action (Kestrel) distills a completed RCA and its fixes into a reusable, generalized runbook for that *class* of incident — symptom, diagnosis steps, remediation steps, verification, and rollback. It requires an upstream RCA step. The generated runbook is available to downstream steps as `{{runbook_html}}` / `{{runbook_markdown}}`, and **Publish Runbook Entry** (Confluence) consumes `runbook_html` automatically.

--- a/docs/workflows/sdk.mdx
+++ b/docs/workflows/sdk.mdx
@@ -665,6 +665,44 @@ wf = (
 
 Polling is durable across server restarts: an in-flight interval resumes its countdown rather than restarting.
 
+### For Each (Fan-Out)
+
+`ForEach` builds a fan-out node that resolves a list from an upstream step's output at runtime and executes ONE embedded catalog action per element, sequentially. Per-item config templates may reference `{{item}}` (the current element), `{{item.<field>}}` (a field of an object element), and `{{item_index}}` (the zero-based index):
+
+```python
+from kestrel.workflows import Workflow, Trigger, Action, ForEach
+
+wf = (
+    Workflow("Ticket per audit finding")
+    .trigger(Trigger.schedule_weekly())
+    # Script writes an array of finding objects to outputs.json:
+    .then(Action("kestrel", "kestrel-execute-script")
+          .config("script", AUDIT_SCRIPT)
+          .label("Audit cluster"))
+    .then(
+        ForEach(
+            "{{step_outputs.action-1.outputs.new_findings}}",
+            Action.jira_create_ticket()
+            .project("SEC")
+            .title("[Audit] {{item.title}}")
+            .body("{{item.description}}"),
+        )
+        .max_items(50)
+        .continue_on_error()
+        .label("Create ticket per finding")
+    )
+    # Runs once, after ALL items have been processed:
+    .then(Action.slack_send_message().channel("security")
+          .message("Filed {{step_outputs.foreach-1.succeeded}} tickets"))
+)
+```
+
+- The items expression must resolve to a list: an array output, a JSON-encoded array string, or a comma-separated string.
+- `.max_items(n)` — caps the fan-out (server default 25, hard cap 100).
+- `.continue_on_error()` — a failed item doesn't fail the node; remaining items still run.
+- The node emits one aggregated output (`items_total`, `items_processed`, `succeeded`, `failed`, per-item `results`, and a flat `summary`), referenced as `{{step_outputs.<foreach-id>.<field>}}`.
+- `ForEach` runs items once each, immediately. To repeatedly re-run an action until a condition holds, use `PollUntil` instead.
+
 ### Approvals
 
 ```python


### PR DESCRIPTION
## Summary
- Adds a **For Each (Fan-Out)** section to the workflow canvas guide (`create-workflows.mdx`): items-path configuration, per-item `{{item}}` / `{{item.<field>}}` / `{{item_index}}` template variables, Max Items capping, Continue on Error, and the aggregated output shape.
- Adds a **ForEach** builder section to the SDK guide (`sdk.mdx`) with a full "ticket per audit finding" example, mirroring the `kestrel` SDK v0.38.0 release.

## Test plan
- [ ] Docs preview renders both new sections correctly
- [ ] Template variable examples match engine behavior ({{item}}, {{item.<field>}}, {{item_index}})

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance for configuring “For Each (Fan-Out)” workflow steps.
  * Documented sequential processing, item templating, item limits, error handling, and aggregated results.
  * Added examples showing fan-out workflows and follow-up actions.
  * Clarified when to use immediate fan-out processing versus repeated conditional waiting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->