### PR TITLE
Add HashiCorp Vault and Infisical integration docs

### DIFF
--- a/docs/integrations/infisical.mdx
+++ b/docs/integrations/infisical.mdx
@@ -18,9 +18,13 @@ Infisical has no outbound control-plane webhooks for organization-level events (
 
 <Steps>
   <Step title="Create a machine identity">
-    In Infisical, go to **Organization → Access Control → Machine Identities** and press **Create Organization Machine Identity** (e.g. `kestrel`). Add a **Universal Auth** method to it and copy the **Client ID** and **Client Secret** — the secret is shown only once.
-
-    Then add the identity to each project your workflows should manage (**Project → Access Control → Machine Identities**), with a role that matches what your workflows do — **Viewer** for read-only monitoring, or a role with secret write permissions if workflows create or update secrets.
+    In Infisical, go to **Organization → Access Control → Machine Identities** and press **Create Organization Machine Identity** (e.g. `kestrel`). Universal Auth is added as its authentication method by default.
+  </Step>
+  <Step title="Get the Universal Auth credentials">
+    On the identity's page, open the **Universal Auth** method under **Authentication** and copy its **Client ID** (this is different from the identity's ID shown in Details), then create a **Client Secret** — the secret is shown only once.
+  </Step>
+  <Step title="Add the identity to your projects">
+    Press **Add to Project** in the **Projects** section (or go to **Project → Access Control → Machine Identities**) for each project your workflows should manage, with a role that matches what your workflows do — **Viewer** for read-only monitoring, or a role with secret write permissions if workflows create or update secrets.
   </Step>
   <Step title="Connect in Kestrel">
     1. Navigate to **Integrations → Infisical** in your Kestrel dashboard.

--- a/docs/integrations/infisical.mdx
+++ b/docs/integrations/infisical.mdx
@@ -18,7 +18,7 @@ Infisical has no outbound control-plane webhooks for organization-level events (
 
 <Steps>
   <Step title="Create a machine identity">
-    In Infisical, go to **Organization → Access Control → Identities** and create a machine identity (e.g. `kestrel`). Add a **Universal Auth** method to it and copy the **Client ID** and **Client Secret** — the secret is shown only once.
+    In Infisical, go to **Organization → Access Control → Machine Identities** and press **Create Organization Machine Identity** (e.g. `kestrel`). Add a **Universal Auth** method to it and copy the **Client ID** and **Client Secret** — the secret is shown only once.
 
     Then add the identity to each project your workflows should manage (**Project → Access Control → Machine Identities**), with a role that matches what your workflows do — **Viewer** for read-only monitoring, or a role with secret write permissions if workflows create or update secrets.
   </Step>

--- a/docs/integrations/infisical.mdx
+++ b/docs/integrations/infisical.mdx
@@ -1,0 +1,79 @@
+---
+title: "Infisical"
+description: "Connect Infisical for secret change monitoring, approval-request and failed-sync alerts, machine-identity tracking, secret and folder management, and AI investigation in workflows"
+---
+
+The Infisical integration connects Kestrel to your Infisical organization (Infisical Cloud or self-hosted) through the Infisical REST API, enabling secret changes, approval requests, failed secret syncs, and new machine identities to trigger workflows and letting workflows read and manage secrets, organize folders, trigger secret syncs, review approval requests, and query audit logs.
+
+Infisical has no outbound control-plane webhooks for organization-level events (its per-project webhooks only signal that *something* changed), so Kestrel polls the Infisical **audit log** and project APIs on a per-tenant cadence to detect secret creates/updates/deletes, new approval requests, failed syncs, and new identities. Polling reads **only metadata and audit events** — secret values are never read or stored by the pollers.
+
+## Prerequisites
+
+- **Organization Admin** role in Kestrel
+- An Infisical organization with at least one project
+- A **Universal Auth machine identity** for Kestrel with access to the projects your workflows manage
+- Audit-log triggers (secret created/updated/deleted, identity created) require an Infisical plan with **audit log API access**
+
+## Setup
+
+<Steps>
+  <Step title="Create a machine identity">
+    In Infisical, go to **Organization → Access Control → Identities** and create a machine identity (e.g. `kestrel`). Add a **Universal Auth** method to it and copy the **Client ID** and **Client Secret** — the secret is shown only once.
+
+    Then add the identity to each project your workflows should manage (**Project → Access Control → Machine Identities**), with a role that matches what your workflows do — **Viewer** for read-only monitoring, or a role with secret write permissions if workflows create or update secrets.
+  </Step>
+  <Step title="Connect in Kestrel">
+    1. Navigate to **Integrations → Infisical** in your Kestrel dashboard.
+    2. Paste the **Client ID** and **Client Secret**.
+    3. Optionally set a custom **Site URL** for self-hosted Infisical (defaults to `https://app.infisical.com`).
+    4. Click **Connect Infisical** — Kestrel validates the credentials by logging in and listing your projects, then starts polling.
+  </Step>
+</Steps>
+
+<Warning>
+  The machine identity can read and write real secrets, depending on the project roles you grant it. Give it the narrowest project access your workflows need, and gate destructive workflow actions (Delete Secret) behind Approval nodes. Kestrel stores the credentials encrypted.
+</Warning>
+
+<Note>
+  All Infisical triggers are detected by polling, so there may be up to one poll interval of delay before a workflow fires. The poll cadence is configurable per trigger (1m–30m, default 5 minutes). Secret-change triggers are derived from the audit log; pollers never read secret values.
+</Note>
+
+## How It's Used
+
+### In Workflows
+
+**Trigger blocks (all poll-based):**
+- **Secret Created / Updated / Deleted** — fire when secrets change in a project (derived from the audit log; values are never read)
+- **Approval Requested** — fires when a secret-change approval request is opened in a project
+- **Secret Sync Failed** — fires when a secret sync to an external destination (AWS, GitHub, etc.) fails
+- **Identity Created** — fires when a new machine identity appears in the organization
+
+Filter secret triggers by project, environment slug, and folder-path prefix. Trigger events expose template variables such as `{{signal.project_id}}`, `{{signal.project_name}}`, `{{signal.environment}}`, `{{signal.secret_path}}`, `{{signal.secret_key}}`, `{{signal.sync_id}}`, `{{signal.sync_name}}`, and `{{signal.actor}}` for downstream steps.
+
+**Action blocks:**
+- **Get Secret** — read a secret (the value output is marked sensitive: it is redacted in run history but can be templated into downstream steps, e.g. to sync into another system)
+- **Create Secret** / **Update Secret** — store or rotate a secret; the value can reference previous step outputs, e.g. a freshly generated credential
+- **Delete Secret** — delete a secret (gate behind an Approval node)
+- **List Secrets** — enumerate secret key names (never values) in a project/environment/path
+- **List Projects** / **List Environments** / **List Folders** / **Create Folder** — inventory and organize the secret hierarchy
+- **List Secret Syncs** / **Trigger Secret Sync** — check sync health and re-run a failed sync
+- **List Approval Requests** — review open secret-change approval requests
+- **Get Audit Logs** — query recent audit events, optionally filtered by project and event type
+- **List Identities** — inventory the organization's machine identities
+- **Investigate Infisical** — run a read-only AI investigation across projects, syncs, approvals, identities, and audit logs (the investigation can never read secret values)
+
+Project, environment, folder, and sync selects use dynamic dropdowns backed by the Infisical API and accept template variables like `{{signal.project_id}}` and `{{signal.sync_id}}` from the trigger.
+
+Example (sync recovery — the flagship Infisical flow): When a **secret sync fails**, post the sync name and project to Slack with approve/reject buttons, then **Trigger Secret Sync** to retry on approval.
+
+Example (change review): When a **secret is updated** in the `prod` environment, fetch recent audit logs for the project and post a summary — who changed what, and when — to your security Slack channel.
+
+Example (governance): When an **approval request** is opened, notify the reviewers' Slack channel with the project and environment, and page via PagerDuty if it is still open after an escalation delay.
+
+## Disconnecting
+
+1. Navigate to **Integrations → Infisical**
+2. Click **Disconnect**
+3. Confirm the disconnection
+
+This stops polling and all Infisical workflow triggers and actions. The stored credentials are deleted from Kestrel; you can also revoke the machine identity's client secret in Infisical. You can reconnect at any time.

--- a/docs/integrations/vault.mdx
+++ b/docs/integrations/vault.mdx
@@ -1,0 +1,87 @@
+---
+title: "HashiCorp Vault"
+description: "Connect HashiCorp Vault for secret rotation automation, seal-status monitoring, stale-secret detection, policy and auth-method change alerts, lease management, and AI investigation in workflows"
+---
+
+The HashiCorp Vault integration connects Kestrel to your Vault cluster (self-hosted or HCP Vault Dedicated) through the Vault HTTP API, enabling seal-status, secret-version, policy, and auth-method changes to trigger workflows and letting workflows read and write KV v2 secrets, rotate database static roles, manage ACL policies, revoke leases and tokens, and run read-only AI investigations.
+
+Vault has no outbound control-plane webhooks (Vault Enterprise event notifications require a WebSocket subscriber inside your network), so Kestrel polls the Vault API on a per-tenant cadence to detect seal-status changes, new secret versions, stale secrets, and policy or auth-method changes. Polling reads **only metadata** — secret values are never read or stored by the pollers.
+
+## Prerequisites
+
+- **Organization Admin** role in Kestrel
+- A reachable Vault cluster (the Kestrel control plane must be able to reach the Vault address over HTTPS)
+- A Vault **token** for Kestrel — a periodic service token bound to a dedicated policy is recommended over a root token
+- KV v2 secrets engines for secret triggers and secret actions; the database secrets engine for static-role rotation
+
+## Setup
+
+<Steps>
+  <Step title="Create a policy and token for Kestrel">
+    Create a dedicated policy that grants only what your workflows need. A typical policy grants `read`, `list` on `sys/health`, `sys/mounts`, `sys/policies/acl/*`, and `sys/auth`, plus `read`, `list` on the metadata paths of the KV mounts you want monitored (e.g. `secret/metadata/*`), and — only if your workflows write secrets or rotate credentials — `create`, `update` on the matching `secret/data/*` and `database/rotate-role/*` paths.
+
+    Then create a token bound to that policy:
+
+    ```bash
+    vault token create -policy=kestrel -period=768h -orphan
+    ```
+  </Step>
+  <Step title="Connect in Kestrel">
+    1. Navigate to **Integrations → Vault** in your Kestrel dashboard.
+    2. Enter your **Vault address** (e.g. `https://vault.example.com:8200`).
+    3. Paste the **token**.
+    4. Optionally set a **namespace** (Vault Enterprise / HCP Vault).
+    5. Click **Connect Vault** — Kestrel validates the connection by reading `sys/health` and starts polling.
+  </Step>
+</Steps>
+
+<Warning>
+  The token can read and write real secrets, depending on the policy you attach. Scope the policy to the narrowest set of paths your workflows need, and gate destructive workflow actions (Delete Secret, Revoke Lease, Revoke Token) behind Approval nodes. Kestrel stores the token encrypted.
+</Warning>
+
+<Note>
+  All Vault triggers are detected by polling, so there may be up to one poll interval of delay before a workflow fires. The poll cadence is configurable per trigger (1m–30m; seal-status checks default to 1 minute, secret and policy checks to 5 minutes). Pollers read only KV **metadata** — never secret values.
+</Note>
+
+## How It's Used
+
+### In Workflows
+
+**Trigger blocks (all poll-based):**
+- **Vault Sealed / Vault Unsealed** — fire when the cluster's seal status changes (a sealed Vault cannot serve secrets)
+- **Health Degraded** — fires when Vault becomes unreachable or reports an unhealthy status
+- **Secret Version Created** — fires when a KV v2 secret gets a new version (metadata diff; values are never read)
+- **Secret Stale** — fires when a secret's latest version exceeds a rotation age threshold (default 90 days, configurable per trigger)
+- **Policy Created / Deleted** — fires when ACL policies change
+- **Auth Method Enabled / Disabled** — fires when authentication methods change
+
+Filter secret triggers by mount and secret-path prefix. Trigger events expose template variables such as `{{signal.mount}}`, `{{signal.secret_path}}`, `{{signal.secret_version}}`, `{{signal.secret_age_days}}`, `{{signal.policy_name}}`, and `{{signal.auth_method}}` for downstream steps.
+
+**Action blocks:**
+- **Read Secret** — read a KV v2 secret (the value output is marked sensitive: it is redacted in run history but can be templated into downstream steps, e.g. to sync into another system)
+- **Write Secret** — create or update a KV v2 secret (creates a new version); the data can reference previous step outputs, e.g. a freshly generated credential
+- **Delete Secret** — soft-delete the latest version, or permanently destroy all versions (gate behind an Approval node)
+- **List Secrets** / **Get Secret Metadata** — enumerate secret names and check version/age metadata without reading values
+- **Rotate Static Role** — rotate the credentials of a database static role immediately
+- **List Mounts** / **List Auth Methods** — inventory of secrets engines and auth methods
+- **List Policies** / **Read Policy** / **Write Policy** — inspect and manage ACL policies from HCL
+- **List Leases** / **Revoke Lease** / **Renew Lease** — manage dynamic-credential leases (revoke during credential-leak response)
+- **Get Health** — check seal/init status and server version
+- **List Token Accessors** / **Revoke Token Accessor** — audit and revoke tokens without knowing the token itself
+- **Investigate Vault** — run a read-only AI investigation across health, mounts, secret metadata, policies, and leases (the investigation can never read secret values)
+
+Mount, secret path, policy, and static-role selects use dynamic dropdowns backed by the Vault API and accept template variables like `{{signal.mount}}` and `{{signal.secret_path}}` from the trigger.
+
+Example (rotation — the flagship Vault flow): When a **secret goes stale** in `secret/app/prod`, post the secret's metadata to Slack with approve/reject buttons, then **Rotate Static Role** (or write a newly generated value with **Write Secret**) on approval and confirm the new version.
+
+Example (incident): When **Vault seals**, page on-call via PagerDuty with the health summary and open a Jira ticket, then post an all-clear to Slack when the **Unsealed** trigger fires.
+
+Example (security): When an **auth method is enabled**, run an AI investigation of recent policy and auth changes and post the findings to your security Slack channel.
+
+## Disconnecting
+
+1. Navigate to **Integrations → Vault**
+2. Click **Disconnect**
+3. Confirm the disconnection
+
+This stops polling and all Vault workflow triggers and actions. The stored token is deleted from Kestrel; revoke it in Vault (`vault token revoke`) if it is no longer needed. You can reconnect at any time.

--- a/docs/introduction.mdx
+++ b/docs/introduction.mdx
@@ -94,6 +94,13 @@ Kestrel connects to your clouds, clusters, PaaS and deployment platforms, AI com
 | [Terraform Cloud](/integrations/terraform) | Run lifecycle automation. **Workflows:** trigger on run events; actions include plan/apply/discard/cancel, workspace locking, variables, state outputs, drift detection, AI investigation |
 | [Pulumi Cloud](/integrations/pulumi) | Stack automation. **Workflows:** trigger on stack/deployment events; actions include stack updates, drift detection and remediation, deployment queue control, stack tags and outputs, AI investigation |
 
+### Secret Management
+
+| Integration | Purpose |
+|---|---|
+| [HashiCorp Vault](/integrations/vault) | Secret lifecycle automation. **Workflows:** trigger on seal-status, secret-version, stale-secret, policy, and auth-method changes (poll-based, metadata only); actions include reading/writing KV secrets, rotating static roles, managing policies and leases, revoking tokens, AI investigation |
+| [Infisical](/integrations/infisical) | Secret management automation. **Workflows:** trigger on secret changes, approval requests, failed syncs, and new identities (poll-based via audit log); actions include managing secrets and folders, triggering syncs, reviewing approvals, querying audit logs, AI investigation |
+
 ### Observability & Analytics
 
 | Integration | Purpose |

--- a/docs/mint.json
+++ b/docs/mint.json
@@ -144,6 +144,8 @@
         "integrations/pulumi",
         "integrations/jenkins",
         "integrations/circleci",
+        "integrations/vault",
+        "integrations/infisical",
         "integrations/knowledge-sources"
       ]
     },

--- a/docs/quickstart/workflows.mdx
+++ b/docs/quickstart/workflows.mdx
@@ -52,6 +52,8 @@ Kestrel Workflows let you automate incident response, cloud resource provisionin
     | **CircleCI** | Workflow Failed, Workflow Succeeded, Workflow Completed, Job Failed |
     | **Terraform Cloud** | Run Created, Run Planning, Run Needs Attention, Run Applying, Run Completed, Run Errored, Drift Detected, Assessment Check Failed |
     | **Pulumi Cloud** | Update Succeeded, Update Failed, Preview Failed, Destroy Succeeded, Deployment Started, Deployment Succeeded, Deployment Failed, Drift Detected, Drift Run Failed, Policy Violation, Stack Created, Stack Deleted |
+    | **HashiCorp Vault** | Vault Sealed, Vault Unsealed, Health Degraded, Secret Version Created, Secret Stale, Policy Created/Deleted, Auth Method Enabled/Disabled |
+    | **Infisical** | Secret Created, Secret Updated, Secret Deleted, Approval Requested, Secret Sync Failed, Identity Created |
     | **Custom Webhook** | Any HTTP POST to your workflow's unique webhook endpoint with HMAC signature verification |
 
     Configure trigger-specific filters to control when the workflow fires — for example, limit a K8s trigger to a specific namespace, cluster, or set of AWS accounts.
@@ -94,6 +96,8 @@ Kestrel Workflows let you automate incident response, cloud resource provisionin
 | Vercel deployment failure | Vercel Deployment Failed | Get build logs → AI investigation → Slack notification |
 | Jenkins build failure RCA | Jenkins Build Failed | Get console log → AI investigation → Slack alert to #ci → Jira ticket |
 | CircleCI flaky-build retry | CircleCI Workflow Failed | Rerun from failed → Wait for pipeline → PagerDuty page if it fails again |
+| Vault stale-secret rotation | Vault Secret Stale | Get secret metadata → Slack approval → Rotate static role → Confirm new version |
+| Infisical sync recovery | Infisical Secret Sync Failed | Slack approval → Trigger secret sync → Notify #secrets on result |
 | Terraform apply approval | Terraform Run Needs Attention | Get run plan summary → Slack approval → Apply or Discard run |
 | Pulumi update failure retry | Pulumi Update Failed | AI investigation → Slack approval → Run deployment (update) → Wait for result |
 | PostHog exception alert | PostHog Session Error | Session summary → Slack alert → Jira ticket if critical |

--- a/docs/workflows/cli.mdx
+++ b/docs/workflows/cli.mdx
@@ -335,7 +335,7 @@ kestrel integrations connect confluence --base-url https://acme.atlassian.net --
 
 | Type | Integrations | How it works |
 |------|--------------|--------------|
-| Token | Cloudflare, PagerDuty, Datadog, ArgoCD, Jenkins, CircleCI, Terraform Cloud, Pulumi Cloud, Vercel, Railway, Fly.io, Nebius, Beam, Daytona, Supabase, PlanetScale, Neon, ClickHouse, PostHog, and more | Prompts for API tokens/credentials (hidden input) and connects immediately |
+| Token | Cloudflare, PagerDuty, Datadog, ArgoCD, Jenkins, CircleCI, Terraform Cloud, Pulumi Cloud, Vercel, Railway, Fly.io, Nebius, Beam, Daytona, Supabase, PlanetScale, Neon, ClickHouse, PostHog, HashiCorp Vault, Infisical, and more | Prompts for API tokens/credentials (hidden input) and connects immediately |
 | OAuth | GitHub, GitLab, Slack | Prints an authorization/install URL to open in your browser |
 | Knowledge | Jira, Linear, Confluence, Notion, Glean | Connects and immediately runs a connection test |
 | Cluster | Kubernetes | Mints an operator token, writes a Helm values file, and prints the `helm install` command |

--- a/docs/workflows/create-workflows.mdx
+++ b/docs/workflows/create-workflows.mdx
@@ -287,6 +287,31 @@ Triggered by Pulumi Cloud stack, update, deployment, drift, and policy events, d
 | Stack Created | Triggers when a new stack is created in the organization |
 | Stack Deleted | Triggers when a stack is deleted from the organization |
 
+### HashiCorp Vault
+
+Triggered by changes detected by **polling** the Vault API (Vault has no outbound control-plane webhooks). Pollers read only KV metadata — never secret values. Filter secret triggers by mount and secret-path prefix; the poll cadence is configurable per trigger (1m–30m).
+
+| Trigger Block | Description |
+|---|---|
+| Vault Sealed | Triggers when the cluster seals (secrets become unavailable) |
+| Vault Unsealed | Triggers when the cluster is unsealed |
+| Health Degraded | Triggers when Vault becomes unreachable or reports an unhealthy status |
+| Secret Version Created | Triggers when a KV v2 secret gets a new version (metadata diff) |
+| Secret Stale | Triggers when a secret's latest version exceeds a rotation age threshold (default 90 days) |
+| Policy Created / Deleted | Triggers when ACL policies change |
+| Auth Method Enabled / Disabled | Triggers when authentication methods change |
+
+### Infisical
+
+Triggered by changes detected by **polling** the Infisical audit log and project APIs. Pollers never read secret values. Filter secret triggers by project, environment slug, and folder-path prefix; the poll cadence is configurable per trigger (1m–30m, default 5m).
+
+| Trigger Block | Description |
+|---|---|
+| Secret Created / Updated / Deleted | Trigger when secrets change in a project (derived from the audit log) |
+| Approval Requested | Triggers when a secret-change approval request is opened |
+| Secret Sync Failed | Triggers when a secret sync to an external destination fails |
+| Identity Created | Triggers when a new machine identity appears in the organization |
+
 ### Custom Webhook
 
 Triggered by an HTTP POST to a unique webhook URL. Accepts any JSON payload with optional HMAC signature verification. See [Custom Integrations](/workflows/custom-integrations) for details.
@@ -358,6 +383,12 @@ Actions are grouped by integration. Each action produces output variables that d
   <Card title="Pulumi Cloud" icon="layer-group">
     List/Get Stack, List/Get Update, Run Deployment, Get/Wait for/Cancel Deployment, Pause/Resume Deployments, Get Stack Outputs, Get Drift Status, Set/Delete Stack Tag, Investigate Pulumi
   </Card>
+  <Card title="HashiCorp Vault" icon="vault">
+    Read/Write/Delete Secret, List Secrets, Get Secret Metadata, Rotate Static Role, List Mounts, List/Read/Write Policy, List Auth Methods, List/Revoke/Renew Lease, Get Health, List/Revoke Token Accessor, Investigate Vault
+  </Card>
+  <Card title="Infisical" icon="key">
+    Get/Create/Update/Delete Secret, List Secrets, List Projects/Environments/Folders, Create Folder, List/Trigger Secret Sync, List Approval Requests, Get Audit Logs, List Identities, Investigate Infisical
+  </Card>
   <Card title="Approval Gates" icon="shield-check">
     Wait for Manual Approval, Wait for Slack Approval, Wait for PR/MR Approval, Refine RCA with Feedback
   </Card>
@@ -423,6 +454,17 @@ Template variables let you pass data between workflow steps. Use double curly br
 | `{{signal.job_number}}` | CircleCI trigger | Number of the job (job-completed events) |
 | `{{signal.status}}` | CircleCI trigger | Workflow/job status (success, failed, error, canceled) |
 | `{{signal.branch}}` | CircleCI trigger | VCS branch the pipeline ran on |
+| `{{signal.mount}}` | Vault trigger | Secrets engine mount (secret events, e.g. `secret/`) |
+| `{{signal.secret_path}}` | Vault / Infisical trigger | Secret path (Vault) or folder path (Infisical); values are never included |
+| `{{signal.secret_version}}` | Vault trigger | New version number (secret.version_created events) |
+| `{{signal.secret_age_days}}` | Vault trigger | Days since the last version (secret.stale events) |
+| `{{signal.policy_name}}` | Vault trigger | ACL policy name (policy events) |
+| `{{signal.auth_method}}` | Vault trigger | Auth method path (auth_method events) |
+| `{{signal.project_id}}` | Infisical trigger | Infisical project the event is about |
+| `{{signal.environment}}` | Infisical trigger | Environment slug (secret events, e.g. `prod`) |
+| `{{signal.secret_key}}` | Infisical trigger | Secret key name (secret events; values are never included) |
+| `{{signal.sync_id}}` | Infisical trigger | Secret sync (sync.failed events) |
+| `{{signal.actor}}` | Infisical trigger | Who performed the action (user email or identity name) |
 | `{{signal.session_id}}` | PostHog trigger | PostHog session ID |
 | `{{signal.workspace}}` | Terraform Cloud trigger | Workspace name |
 | `{{signal.run_id}}` | Terraform Cloud trigger | Run ID (run-...) |
@@ -463,7 +505,7 @@ Cooldowns prevent a workflow from firing repeatedly for the same event. Configur
 |--------|----------|-------------|
 | No cooldown | 0 | — |
 | 5 minutes | 5m | — |
-| 10 minutes | 10m | Slack, PostHog, Vercel, Railway, Fly.io, Nebius, Jenkins, CircleCI, Terraform Cloud, Pulumi Cloud, custom webhook triggers |
+| 10 minutes | 10m | Slack, PostHog, Vercel, Railway, Fly.io, Nebius, Jenkins, CircleCI, Terraform Cloud, Pulumi Cloud, Vault, Infisical, custom webhook triggers |
 | 30 minutes | 30m | — |
 | 1 hour | 1h | — |
 | 3 hours | 3h | — |
@@ -687,6 +729,29 @@ On **Request changes**, the reviewer's free-text guidance re-runs the RCA agent 
 | **Action 4** | PagerDuty Create Alert | Summary: `{{step_outputs.action-3.summary}}` |
 
 ### PostHog Exception → Investigation → Slack
+
+### Vault Stale Secret → Slack Approval → Rotate → Confirm
+
+**Workflow Agent prompt:** *"When a secret in secret/app/prod hasn't been rotated in 60 days, post its metadata to #secrets in Slack and ask for approval, then rotate the database static role and confirm the rotation."*
+
+| Step | Type | Configuration |
+|------|------|---------------|
+| **Trigger** | Vault Secret Stale | Mount: `secret/`, paths: `app/prod`, max age: 60 days |
+| **Action 1** | Get Secret Metadata | Mount: `{{signal.mount}}`, Path: `{{signal.secret_path}}` |
+| **Action 2** | Wait for Slack Approval | Channel: `#secrets`, message includes `{{signal.secret_path}}` age `{{signal.secret_age_days}}` days |
+| **On Approved → Action 3** | Rotate Static Role | Mount: `database/`, Role: `app-db` |
+| **Action 4** | Slack Send Message | Channel: `#secrets`, message: `{{step_outputs.action-3.summary}}` |
+
+### Infisical Sync Failure → Slack Approval → Retry Sync
+
+**Workflow Agent prompt:** *"When an Infisical secret sync fails, ask for approval in #secrets, then re-trigger the sync and report the result."*
+
+| Step | Type | Configuration |
+|------|------|---------------|
+| **Trigger** | Infisical Secret Sync Failed | All projects |
+| **Action 1** | Wait for Slack Approval | Channel: `#secrets`, message includes `{{signal.sync_name}}` in `{{signal.project_name}}` |
+| **On Approved → Action 2** | Trigger Secret Sync | Sync: `{{signal.sync_id}}` |
+| **Action 3** | Slack Send Message | Channel: `#secrets`, message: `{{step_outputs.action-2.summary}}` |
 
 **Workflow Agent prompt:** *"When PostHog captures a frontend exception, generate an AI summary of the user's session including what they were doing before the error, and send the summary with the replay URL to #product-alerts in Slack."*
 

--- a/docs/workflows/observability.mdx
+++ b/docs/workflows/observability.mdx
@@ -18,7 +18,7 @@ The top of the dashboard shows aggregate metrics across all workflows:
 | **Total Executions** | Number of workflow runs in the selected time range |
 | **Success Rate** | Percentage of executions that completed without errors |
 | **Active Workflows** | Number of enabled workflows |
-| **Trigger Sources** | Breakdown of executions by trigger type (K8s, Cloud, Slack, PagerDuty, PostHog, Vercel, Railway, Fly.io, Nebius, Jenkins, CircleCI, Terraform Cloud, Pulumi Cloud, Webhook) |
+| **Trigger Sources** | Breakdown of executions by trigger type (K8s, Cloud, Slack, PagerDuty, PostHog, Vercel, Railway, Fly.io, Nebius, Jenkins, CircleCI, Terraform Cloud, Pulumi Cloud, Vault, Infisical, Webhook) |
 
 Use the date range picker in the top-right corner to adjust the time window. Defaults to the last 7 days.
 
@@ -83,7 +83,7 @@ The execution history table lists every workflow run with filtering and search.
 |--------|---------|
 | **Workflow** | Select a specific workflow or view all |
 | **Status** | Success, Failed, Running, Pending Approval, Timed Out |
-| **Trigger Source** | K8s Incident, Cloud Signal, Slack, PagerDuty, PostHog, Vercel, Railway, Fly.io, Nebius, Jenkins, CircleCI, Terraform Cloud, Pulumi Cloud, Webhook |
+| **Trigger Source** | K8s Incident, Cloud Signal, Slack, PagerDuty, PostHog, Vercel, Railway, Fly.io, Nebius, Jenkins, CircleCI, Terraform Cloud, Pulumi Cloud, Vault, Infisical, Webhook |
 | **Date Range** | Custom start and end dates |
 
 {/* Screenshot placeholder: Execution history table with filter controls and status badges */}

--- a/docs/workflows/sdk.mdx
+++ b/docs/workflows/sdk.mdx
@@ -233,6 +233,27 @@ Trigger.pulumi_stack_created()
 Trigger.pulumi_stack_deleted()
 Trigger.pulumi_any()
 
+# HashiCorp Vault (poll-based; metadata only — secret values are never read)
+Trigger.vault_sealed()
+Trigger.vault_unsealed()
+Trigger.vault_health_degraded()
+Trigger.vault_secret_version_created()    # KV v2 metadata diff
+Trigger.vault_secret_stale()              # age threshold via .vault_secret_max_age_days()
+Trigger.vault_policy_created()
+Trigger.vault_policy_deleted()
+Trigger.vault_auth_method_enabled()
+Trigger.vault_auth_method_disabled()
+Trigger.vault_any()
+
+# Infisical (poll-based via audit log; secret values are never read)
+Trigger.infisical_secret_created()
+Trigger.infisical_secret_updated()
+Trigger.infisical_secret_deleted()
+Trigger.infisical_approval_requested()
+Trigger.infisical_secret_sync_failed()
+Trigger.infisical_identity_created()
+Trigger.infisical_any()
+
 # Developer Requests (on-demand via Slack /kestrel-workflow, Kestrel Platform UI, or CLI)
 Trigger.request_kubernetes()    # Kubernetes operations
 Trigger.request_cloud()         # AWS / Cloud operations
@@ -248,6 +269,8 @@ Trigger.request_jenkins()       # Jenkins operations
 Trigger.request_circleci()      # CircleCI operations
 Trigger.request_terraform()     # Terraform Cloud operations
 Trigger.request_pulumi()        # Pulumi Cloud operations
+Trigger.request_vault()         # HashiCorp Vault operations
+Trigger.request_infisical()     # Infisical operations
 Trigger.request_general()       # General (catch-all)
 ```
 
@@ -367,6 +390,26 @@ trigger = (
     Trigger.pulumi_update_failed()
     .pulumi_stacks("my-project/prod")    # project/stack refs or bare stack names; omit or "*" for all
     .pulumi_projects("my-project")       # optional: filter by Pulumi project name
+)
+```
+
+Vault and Infisical triggers are poll-based (no outbound webhooks; only metadata and audit events are read — never secret values). Scope secret triggers and tune the poll cadence:
+
+```python
+trigger = (
+    Trigger.vault_secret_stale()
+    .vault_mounts("secret/")                   # KV v2 mounts; omit or "*" for all
+    .vault_secret_paths("app/prod")            # path prefixes within the mount
+    .vault_secret_max_age_days(60)             # rotation age threshold (default 90)
+    .vault_poll_interval("15m")                # 1m | 5m | 15m | 30m
+)
+
+trigger = (
+    Trigger.infisical_secret_updated()
+    .infisical_projects("proj-id")             # project IDs; omit or "*" for all
+    .infisical_environments("prod")            # environment slugs
+    .infisical_secret_paths("/backend")        # folder path prefixes
+    .infisical_poll_interval("5m")             # 1m | 5m | 15m | 30m
 )
 ```
 
@@ -608,6 +651,45 @@ Action.pulumi_get_drift().stack("my-project/prod")
 Action.pulumi_set_stack_tag().stack("{{signal.stack}}").tag_name("kestrel:quarantined").tag_value("true")
 Action.pulumi_delete_stack_tag().stack("{{signal.stack}}").tag_name("kestrel:quarantined")
 Action.pulumi_investigate().query("Why did the update fail?").stack("{{signal.stack}}")
+
+# HashiCorp Vault (KV-scoped: .mount() + .path(); read-secret values are sensitive
+# — redacted in run history but usable in downstream templates)
+Action.vault_read_secret().mount("secret/").path("app/prod/db").secret_key("password")
+Action.vault_write_secret().mount("secret/").path("app/prod/db").secret_data('{"password": "{{step_outputs.action-1.value}}"}')
+Action.vault_delete_secret().mount("secret/").path("app/old").destroy()    # gate behind approval
+Action.vault_list_secrets().mount("secret/").path("app/prod")
+Action.vault_get_secret_metadata().mount("{{signal.mount}}").path("{{signal.secret_path}}")
+Action.vault_rotate_static_role().mount("database/").role("app-db")
+Action.vault_list_mounts()
+Action.vault_list_policies()
+Action.vault_read_policy().name("{{signal.policy_name}}")
+Action.vault_write_policy().name("app-read").policy_hcl('path "secret/data/app/*" { capabilities = ["read"] }')
+Action.vault_list_auth_methods()
+Action.vault_list_leases().lease_prefix("database/creds")
+Action.vault_revoke_lease().lease_id("{{step_outputs.action-1.keys}}")     # credential-leak response
+Action.vault_renew_lease().lease_id("database/creds/app/abc").increment(3600)
+Action.vault_get_health()
+Action.vault_list_token_accessors()
+Action.vault_revoke_token_accessor().accessor("hmac.abc123")               # gate behind approval
+Action.vault_investigate().query("Why is this secret stale?").mount("{{signal.mount}}")
+
+# Infisical (project-scoped: .infisical_project() + .environment() + .secret_path();
+# get-secret values are sensitive — redacted in run history but usable in templates)
+Action.infisical_get_secret().infisical_project("backend").environment("prod").secret_path("/api").secret_key("DB_PASSWORD")
+Action.infisical_create_secret().infisical_project("backend").environment("prod").secret_key("API_KEY").secret_value("{{step_outputs.action-1.value}}")
+Action.infisical_update_secret().infisical_project("backend").environment("prod").secret_key("API_KEY").secret_value("...")
+Action.infisical_delete_secret().infisical_project("backend").environment("prod").secret_key("OLD_KEY")   # gate behind approval
+Action.infisical_list_secrets().infisical_project("backend").environment("prod")   # key names only, never values
+Action.infisical_list_projects()
+Action.infisical_list_environments().infisical_project("backend")
+Action.infisical_list_folders().infisical_project("backend").environment("prod").path("/")
+Action.infisical_create_folder().infisical_project("backend").environment("prod").path("/").name("payments")
+Action.infisical_list_secret_syncs().infisical_project("{{signal.project_id}}")
+Action.infisical_trigger_secret_sync().sync_id("{{signal.sync_id}}")       # retry a failed sync
+Action.infisical_list_approval_requests().infisical_project("{{signal.project_id}}")
+Action.infisical_get_audit_logs().infisical_project("{{signal.project_id}}").event_type("delete-secret").limit(100)
+Action.infisical_list_identities()
+Action.infisical_investigate().query("Which syncs are failing and why?")
 
 # Approval Gates
 Action.approval_manual()

--- a/docs/workflows/setup-integrations.mdx
+++ b/docs/workflows/setup-integrations.mdx
@@ -132,6 +132,17 @@ Prefer the terminal? Every integration can also be connected with the [Kestrel C
   </Card>
 </CardGroup>
 
+## Secret Management
+
+<CardGroup cols={2}>
+  <Card title="HashiCorp Vault" icon="vault" href="/integrations/vault">
+    **Triggers (poll-based):** Vault Sealed/Unsealed, Health Degraded, Secret Version Created, Secret Stale, Policy Created/Deleted, Auth Method Enabled/Disabled. **Actions:** Read/Write/Delete Secret, List Secrets, Get Secret Metadata, Rotate Static Role, List Mounts, List/Read/Write Policy, List Auth Methods, List/Revoke/Renew Lease, Get Health, List/Revoke Token Accessor, Investigate Vault.
+  </Card>
+  <Card title="Infisical" icon="key" href="/integrations/infisical">
+    **Triggers (poll-based):** Secret Created/Updated/Deleted, Approval Requested, Secret Sync Failed, Identity Created. **Actions:** Get/Create/Update/Delete Secret, List Secrets, List Projects/Environments/Folders, Create Folder, List/Trigger Secret Sync, List Approval Requests, Get Audit Logs, List Identities, Investigate Infisical.
+  </Card>
+</CardGroup>
+
 ## Cost Management
 
 AWS Cost features are available through the [AWS integration](/integrations/aws). No separate setup is required — cost management actions are enabled when you connect an AWS account.


### PR DESCRIPTION
## Summary
- Adds documentation for the new HashiCorp Vault and Infisical secret management integrations
- New dedicated setup pages: `docs/integrations/vault.mdx` and `docs/integrations/infisical.mdx` (features, prerequisites, token/machine-identity setup, security notes, polling behavior, workflow usage, template variables, disconnection)
- Registers both pages in the `mint.json` sidebar and adds a "Secret Management" section to the introduction and setup-integrations pages
- Updates workflow docs: trigger/action references, template variables, cooldown presets, trigger-source lists, SDK trigger/action examples, and example workflows (Vault stale-secret rotation, Infisical sync recovery)

## Notes
- Docs-only change; the Vault/Infisical workflow blocks run server-side, so no operator code changes are required.
- Both integrations are poll-based (no outbound webhooks) and never read secret values during polling — only metadata.

## Test plan
- [ ] Docs preview renders both new integration pages
- [ ] Sidebar shows Vault and Infisical under Integrations
- [ ] Internal links from introduction/setup-integrations resolve

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Added new documentation for the HashiCorp Vault and Infisical integrations, including prerequisites, polling-based change detection, security guidance, available triggers/actions, and disconnect flows.
  - Expanded workflow documentation (trigger/action catalogs, template variables, cooldown presets) and added new end-to-end examples for Vault and Infisical.
  - Updated quickstarts, CLI connection-type tables, observability trigger-source filters, and Python SDK trigger/action catalogs to include both integrations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->