### PR TITLE
docs: add Databricks integration

### DIFF
--- a/docs/integrations/databricks.mdx
+++ b/docs/integrations/databricks.mdx
@@ -15,7 +15,7 @@ The Databricks integration connects Kestrel to your Databricks workspace through
 
 <Steps>
   <Step title="Generate an access token">
-    In your Databricks workspace, go to **Settings → Developer → Access tokens → Generate new token**. Copy the token — it is shown only once. For production, create the token for a service principal with access scoped to the jobs, clusters, pipelines, and warehouses you want to automate.
+    In your Databricks workspace, go to **Settings → Developer → Access tokens → Generate new token**. Under **Scope**, choose **Other APIs** and select the **jobs**, **clusters**, **pipelines**, **sql**, and **query-history** API scopes — these cover every Kestrel trigger and action block (avoid "all APIs"). Copy the token — it is shown only once. For production, create the token for a service principal with access scoped to the jobs, clusters, pipelines, and warehouses you want to automate.
   </Step>
   <Step title="Find your workspace URL">
     The workspace base URL from your browser's address bar, e.g. `https://dbc-a1b2c3d4-e5f6.cloud.databricks.com` (Azure: `https://adb-xxxx.azuredatabricks.net`, GCP: `https://xxxx.gcp.databricks.com`).

--- a/docs/integrations/databricks.mdx
+++ b/docs/integrations/databricks.mdx
@@ -1,0 +1,78 @@
+---
+title: "Databricks"
+description: "Connect Databricks for data-platform automation — react to failed job runs, cluster terminations, and DLT pipeline failures, repair runs, manage clusters and SQL warehouses, and run data-quality checks in workflows"
+---
+
+The Databricks integration connects Kestrel to your Databricks workspace through the Databricks REST API, enabling failed job runs, unexpected cluster terminations, and Delta Live Tables pipeline failures to trigger workflows, and letting workflows run and repair jobs, fetch run output for triage, manage cluster and SQL warehouse lifecycle, start pipeline updates, execute SQL data-quality checks, and run read-only AI investigations.
+
+## Prerequisites
+
+- **Organization Admin** role in Kestrel
+- A Databricks workspace on AWS, Azure, or GCP
+- A Databricks **personal access token** (a service-principal token is recommended for production) and your **workspace URL**
+
+## Setup
+
+<Steps>
+  <Step title="Generate an access token">
+    In your Databricks workspace, go to **Settings → Developer → Access tokens → Generate new token**. Copy the token — it is shown only once. For production, create the token for a service principal with access scoped to the jobs, clusters, pipelines, and warehouses you want to automate.
+  </Step>
+  <Step title="Find your workspace URL">
+    The workspace base URL from your browser's address bar, e.g. `https://dbc-a1b2c3d4-e5f6.cloud.databricks.com` (Azure: `https://adb-xxxx.azuredatabricks.net`, GCP: `https://xxxx.gcp.databricks.com`).
+  </Step>
+  <Step title="Connect in Kestrel">
+    1. Navigate to **Integrations → Databricks** in your Kestrel dashboard.
+    2. Enter your **workspace URL** and paste the **access token**.
+    3. Click **Connect Databricks** — Kestrel validates the token against your workspace.
+  </Step>
+</Steps>
+
+<Note>
+  No webhooks needed — Databricks has no tenant-wide outbound webhooks, so Kestrel polls the Databricks REST API for job-run, cluster, and pipeline events. The poll cadence is configurable per trigger (1m–30m, default 5m).
+</Note>
+
+## How It's Used
+
+### In Workflows
+
+**Trigger blocks (polling):**
+- **Job Run Failed** — fires when a job run terminates `FAILED`, `TIMEDOUT`, or `CANCELED`
+- **Job Run Succeeded** — fires when a job run completes successfully
+- **Job Run Exceeded Duration** — fires when a still-running run passes a duration threshold (catch stuck or runaway jobs before they burn compute)
+- **Cluster Terminated Unexpectedly** — fires on error terminations (Spark failures, cloud-provider launch failures, unresponsive drivers); expected user/auto-stop terminations don't fire
+- **DLT Pipeline Update Failed** — fires when a Delta Live Tables pipeline update fails
+
+Scope triggers by job, cluster, or pipeline, and set the duration threshold and poll interval per trigger. Trigger events expose template variables such as `{{signal.job_name}}`, `{{signal.run_id}}`, `{{signal.run_page_url}}`, `{{signal.result_state}}`, `{{signal.error_message}}`, `{{signal.duration_seconds}}`, `{{signal.cluster_name}}`, `{{signal.termination_reason}}`, and `{{signal.pipeline_name}}` for downstream steps.
+
+**Action blocks (jobs):**
+- **Run Job Now** — trigger a job run, optionally with job parameters
+- **Get Run / Get Run Output** — run state, duration, per-task states, errors, stack traces, and notebook output (multi-task runs automatically target the first failed task's output)
+- **Cancel Run** — stop a runaway or stuck run
+- **Repair Run** — re-run only the failed tasks of a run, reusing successful task results — the fastest recovery from a partial failure
+
+**Action blocks (clusters and pipelines):**
+- **Start / Restart / Terminate Cluster** — cluster lifecycle for recovery and cost control
+- **Start Pipeline Update / Stop Pipeline** — re-run a failed DLT pipeline (optionally full-refresh) or stop an in-progress update
+
+**Action blocks (SQL):**
+- **Execute SQL** — run a statement on a SQL warehouse and use the result in later steps (`{{step_outputs.ID.first_value}}` pairs naturally with Condition nodes for data-quality gates)
+- **Start / Stop SQL Warehouse** — warehouse lifecycle for scheduled cost control
+
+**Action blocks (AI):**
+- **Investigate Databricks** — run a read-only AI investigation across jobs, runs, clusters, pipelines, and warehouses (the investigation can never mutate the workspace — every Databricks write is blocked)
+
+Job, cluster, pipeline, and warehouse selects use dynamic dropdowns backed by the Databricks API and default to `{{signal.job_id}}` / `{{signal.run_id}}` / `{{signal.cluster_id}}` / `{{signal.pipeline_id}}` when the workflow starts from a Databricks trigger. Destructive actions (terminate cluster, cancel run, stop pipeline) pair naturally with Approval nodes.
+
+Example (failure recovery): When the **nightly ETL job fails**, fetch the run output, repair the failed tasks, and post the error summary with the run page link to the data-platform Slack channel — escalating to PagerDuty if the repair fails too.
+
+Example (cost control): On a nightly schedule, stop non-production SQL warehouses and terminate idle all-purpose clusters after Slack approval.
+
+Example (data quality): Every morning, execute a freshness SQL check against the lakehouse; if the stale-row count exceeds zero, open a Jira ticket and alert the data-eng channel.
+
+## Disconnecting
+
+1. Navigate to **Integrations → Databricks**
+2. Click **Disconnect**
+3. Confirm the disconnection
+
+This disables all Databricks workflow triggers and actions. The stored access token is deleted from Kestrel; also revoke the token in Databricks under **Settings → Developer → Access tokens** if it is no longer needed.

--- a/docs/introduction.mdx
+++ b/docs/introduction.mdx
@@ -73,6 +73,7 @@ Kestrel connects to your clouds, clusters, PaaS and deployment platforms, AI com
 | [Neon](/integrations/neon) | Serverless Postgres. **Workflows:** actions include branch lifecycle, point-in-time restore, compute suspend/resume and autoscaling, reset-from-parent, credential rotation, AI investigation |
 | [PlanetScale](/integrations/planetscale) | MySQL branching and schema migrations. **Workflows:** trigger on branch/deploy-request events; actions include branch, deploy-request (schema migration), backup, and credential automation |
 | [ClickHouse](/integrations/clickhouse) | ClickHouse Cloud services. **Workflows:** trigger on error spikes; actions include service start/stop/scale, IP access lists, backups, ClickPipes ingestion, usage costs, AI investigation |
+| [Databricks](/integrations/databricks) | Databricks data platform. **Workflows:** trigger on failed/succeeded/long-running job runs, unexpected cluster terminations, and DLT pipeline failures (poll-based); actions include run/repair/cancel jobs, run output triage, cluster and SQL warehouse lifecycle, DLT pipeline updates, SQL data-quality checks, AI investigation |
 
 ### CI/CD & GitOps
 

--- a/docs/mint.json
+++ b/docs/mint.json
@@ -133,6 +133,7 @@
         "integrations/planetscale",
         "integrations/neon",
         "integrations/clickhouse",
+        "integrations/databricks",
         "integrations/datadog",
         "integrations/opentelemetry",
         "integrations/argocd",

--- a/docs/workflows/setup-integrations.mdx
+++ b/docs/workflows/setup-integrations.mdx
@@ -133,6 +133,9 @@ Prefer the terminal? Every integration can also be connected with the [Kestrel C
   <Card title="ClickHouse" icon="database" href="/integrations/clickhouse">
     **Triggers (poll-based):** Service State Changed, Service Idle, Service Scaled, Backup Completed/Failed, Query Error Spike, ClickPipe Failed, Version Changed, Usage/Spend Threshold, Too Many Parts, High Query Concurrency. **Actions:** List/Get/Create/Start/Stop/Delete Service, Update Autoscaling, Update IP Access List, List/Get Backup, Update Backup Configuration, Restore Backup, List API Keys, Get Service Metrics, Get Usage Costs, List/Get/Start/Stop/Resync/Scale ClickPipe, Get/Set/Clear Autoscaling Schedule, Get/Set/Clear Upgrade Window, Get/Update/Reset Setting, Get/Upsert/Delete Query Endpoint, List Members, Remove Member, List Roles, List Activity, Investigate ClickHouse.
   </Card>
+  <Card title="Databricks" icon="database" href="/integrations/databricks">
+    **Triggers (poll-based):** Job Run Failed/Succeeded, Job Run Exceeded Duration, Cluster Terminated Unexpectedly, DLT Pipeline Update Failed. **Actions:** List Jobs, Run Job Now, Get Run, Get Run Output, Cancel Run, Repair Run, List/Get Cluster, Start/Restart/Terminate Cluster, List Pipelines, Start Pipeline Update, Stop Pipeline, Execute SQL, List SQL Warehouses, Start/Stop SQL Warehouse, Investigate Databricks.
+  </Card>
 </CardGroup>
 
 ## Secret Management


### PR DESCRIPTION
## Summary
- Adds `docs/integrations/databricks.mdx` covering setup (PAT + workspace URL), poll-based triggers (job run failed/succeeded/long-running, cluster terminated unexpectedly, DLT pipeline update failed), action blocks (jobs, clusters, pipelines, SQL warehouses), template variables, and example workflows
- Registers the page in `mint.json` and adds Databricks to the integrations tables in `introduction.mdx` and `workflows/setup-integrations.mdx`

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive Databricks integration documentation, including setup, authentication, supported actions, workflow triggers, resource selection, and disconnect behavior.
  * Added Databricks to the integrations overview and deployment integration listings.
  * Added the Databricks guide to the documentation navigation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->